### PR TITLE
Chore(SCT-1008): Add setup for accessing secrets in the App Script Code

### DIFF
--- a/google-scripts/process-form-submission/__mocks__/google_mocks.ts
+++ b/google-scripts/process-form-submission/__mocks__/google_mocks.ts
@@ -16,3 +16,13 @@ export class MockSpreadsheetApp {
     return MockSpreadsheetApp.mockActiveSpreadsheet;
   }
 }
+
+export class MockPropertiesService {
+  static mockProperties = {
+    getProperty: jest.fn(),
+  } as unknown as GoogleAppsScript.Properties.Properties;
+
+  getScriptProperties() {
+    return MockPropertiesService.mockProperties;
+  }
+}

--- a/google-scripts/process-form-submission/__tests__/getProperties.test.ts
+++ b/google-scripts/process-form-submission/__tests__/getProperties.test.ts
@@ -1,4 +1,4 @@
-import { getProperties } from "../getProperties";
+import getProperties from "../getProperties";
 import { MockPropertiesService } from "../__mocks__/google_mocks";
 
 describe.only("#getProperties", () => {

--- a/google-scripts/process-form-submission/__tests__/getProperties.test.ts
+++ b/google-scripts/process-form-submission/__tests__/getProperties.test.ts
@@ -1,4 +1,4 @@
-import getProperties from "../getProperties";
+import {getProperties} from "../getProperties";
 import { MockPropertiesService } from "../__mocks__/google_mocks";
 
 describe.only("#getProperties", () => {

--- a/google-scripts/process-form-submission/__tests__/getProperties.test.ts
+++ b/google-scripts/process-form-submission/__tests__/getProperties.test.ts
@@ -1,4 +1,4 @@
-import {getProperties} from "../getProperties";
+import { getProperties } from "../getProperties";
 import { MockPropertiesService } from "../__mocks__/google_mocks";
 
 describe("#getProperties", () => {
@@ -18,7 +18,9 @@ describe("#getProperties", () => {
     ]);
 
     (
-      MockPropertiesService.mockProperties.getProperty as jest.Mock<string | null>
+      MockPropertiesService.mockProperties.getProperty as jest.Mock<
+        string | null
+      >
     ).mockImplementation((a) => {
       if (testProperties.has(a)) {
         return testProperties.get(a) as string | null;

--- a/google-scripts/process-form-submission/__tests__/getProperties.test.ts
+++ b/google-scripts/process-form-submission/__tests__/getProperties.test.ts
@@ -1,7 +1,7 @@
 import {getProperties} from "../getProperties";
 import { MockPropertiesService } from "../__mocks__/google_mocks";
 
-describe.only("#getProperties", () => {
+describe("#getProperties", () => {
   let testProperties: Map<string, string | null>;
 
   const MASH_SHEET_NAME = "EXAMPLE_SHEET_NAME";

--- a/google-scripts/process-form-submission/__tests__/getProperties.test.ts
+++ b/google-scripts/process-form-submission/__tests__/getProperties.test.ts
@@ -1,0 +1,105 @@
+import { getProperties } from "../getProperties";
+import { MockPropertiesService } from "../__mocks__/google_mocks";
+
+describe.only("#getProperties", () => {
+  let testProperties: Map<string, string | null>;
+
+  const MASH_SHEET_NAME = "EXAMPLE_SHEET_NAME";
+  const REFFERALS_BUCKET_URL = "EXAMPLE_S3_URL";
+  const UNIQUE_ID_COLUMN_NO = "1";
+  const REFFERALS_BUCKET_API_KEY = "EXAMPLE_API_KEY";
+
+  beforeEach(() => {
+    testProperties = new Map([
+      ["MASH_SHEET_NAME", MASH_SHEET_NAME],
+      ["REFFERALS_BUCKET_URL", REFFERALS_BUCKET_URL],
+      ["UNIQUE_ID_COLUMN_NO", UNIQUE_ID_COLUMN_NO],
+      ["REFFERALS_BUCKET_API_KEY", REFFERALS_BUCKET_API_KEY],
+    ]);
+
+    (
+      MockPropertiesService.mockProperties.getProperty as jest.Mock<string | null>
+    ).mockImplementation((a) => {
+      if (testProperties.has(a)) {
+        return testProperties.get(a) as string | null;
+      }
+      return "";
+    });
+
+    global.PropertiesService =
+      new MockPropertiesService() as unknown as GoogleAppsScript.Properties.PropertiesService;
+  });
+
+  it("should return an object containing our properties when validation passes", () => {
+    expect(getProperties()).toEqual({
+      FORM_SUBMISSION_ID_COLUMN_POSITION: UNIQUE_ID_COLUMN_NO,
+      REFERRALS_SHEET_NAME: MASH_SHEET_NAME,
+      S3_ENDPOINT_API: REFFERALS_BUCKET_URL,
+      S3_ENDPOINT_API_KEY: REFFERALS_BUCKET_API_KEY,
+    });
+  });
+
+  it("should raise an error if sheet name property is empty", () => {
+    testProperties.set("MASH_SHEET_NAME", "");
+
+    expect(getProperties).toThrow(
+      "Property MASH_SHEET_NAME could not be found"
+    );
+  });
+
+  it("should raise an error if REFFERALS_BUCKET_URL property is empty", () => {
+    testProperties.set("REFFERALS_BUCKET_URL", "");
+
+    expect(getProperties).toThrow(
+      "Property REFFERALS_BUCKET_URL could not be found"
+    );
+  });
+
+  it("should raise an error if UNIQUE_ID_COLUMN_NO property is empty", () => {
+    testProperties.set("UNIQUE_ID_COLUMN_NO", "");
+
+    expect(getProperties).toThrow(
+      "Property UNIQUE_ID_COLUMN_NO could not be found"
+    );
+  });
+
+  it("should raise an error if REFFERALS_BUCKET_API_KEY property is empty", () => {
+    testProperties.set("REFFERALS_BUCKET_API_KEY", "");
+
+    expect(getProperties).toThrow(
+      "Property REFFERALS_BUCKET_API_KEY could not be found"
+    );
+  });
+
+  it("should raise an error if sheet name property is null", () => {
+    testProperties.set("MASH_SHEET_NAME", null);
+
+    expect(getProperties).toThrow(
+      "Property MASH_SHEET_NAME could not be found"
+    );
+  });
+
+  it("should raise an error if REFFERALS_BUCKET_URL property is null", () => {
+    testProperties.set("REFFERALS_BUCKET_URL", null);
+
+    expect(getProperties).toThrow(
+      "Property REFFERALS_BUCKET_URL could not be found"
+    );
+  });
+
+  it("should raise an error if UNIQUE_ID_COLUMN_NO property is null", () => {
+    testProperties.set("UNIQUE_ID_COLUMN_NO", null);
+
+    expect(getProperties).toThrow(
+      "Property UNIQUE_ID_COLUMN_NO could not be found"
+    );
+  });
+
+  it("should raise an error if REFFERALS_BUCKET_API_KEY property is null", () => {
+    testProperties.set("REFFERALS_BUCKET_API_KEY", null);
+
+    expect(getProperties).toThrow(
+      "Property REFFERALS_BUCKET_API_KEY could not be found"
+    );
+  });
+});

--- a/google-scripts/process-form-submission/__tests__/getProperties.test.ts
+++ b/google-scripts/process-form-submission/__tests__/getProperties.test.ts
@@ -5,16 +5,16 @@ describe.only("#getProperties", () => {
   let testProperties: Map<string, string | null>;
 
   const MASH_SHEET_NAME = "EXAMPLE_SHEET_NAME";
-  const REFFERALS_BUCKET_URL = "EXAMPLE_S3_URL";
+  const REFERRALS_BUCKET_URL = "EXAMPLE_S3_URL";
   const UNIQUE_ID_COLUMN_NO = "1";
-  const REFFERALS_BUCKET_API_KEY = "EXAMPLE_API_KEY";
+  const REFERRALS_BUCKET_API_KEY = "EXAMPLE_API_KEY";
 
   beforeEach(() => {
     testProperties = new Map([
       ["MASH_SHEET_NAME", MASH_SHEET_NAME],
-      ["REFFERALS_BUCKET_URL", REFFERALS_BUCKET_URL],
+      ["REFERRALS_BUCKET_URL", REFERRALS_BUCKET_URL],
       ["UNIQUE_ID_COLUMN_NO", UNIQUE_ID_COLUMN_NO],
-      ["REFFERALS_BUCKET_API_KEY", REFFERALS_BUCKET_API_KEY],
+      ["REFERRALS_BUCKET_API_KEY", REFERRALS_BUCKET_API_KEY],
     ]);
 
     (
@@ -34,8 +34,8 @@ describe.only("#getProperties", () => {
     expect(getProperties()).toEqual({
       FORM_SUBMISSION_ID_COLUMN_POSITION: UNIQUE_ID_COLUMN_NO,
       REFERRALS_SHEET_NAME: MASH_SHEET_NAME,
-      S3_ENDPOINT_API: REFFERALS_BUCKET_URL,
-      S3_ENDPOINT_API_KEY: REFFERALS_BUCKET_API_KEY,
+      S3_ENDPOINT_API: REFERRALS_BUCKET_URL,
+      S3_ENDPOINT_API_KEY: REFERRALS_BUCKET_API_KEY,
     });
   });
 
@@ -47,11 +47,11 @@ describe.only("#getProperties", () => {
     );
   });
 
-  it("should raise an error if REFFERALS_BUCKET_URL property is empty", () => {
-    testProperties.set("REFFERALS_BUCKET_URL", "");
+  it("should raise an error if REFERRALS_BUCKET_URL property is empty", () => {
+    testProperties.set("REFERRALS_BUCKET_URL", "");
 
     expect(getProperties).toThrow(
-      "Property REFFERALS_BUCKET_URL could not be found"
+      "Property REFERRALS_BUCKET_URL could not be found"
     );
   });
 
@@ -63,11 +63,11 @@ describe.only("#getProperties", () => {
     );
   });
 
-  it("should raise an error if REFFERALS_BUCKET_API_KEY property is empty", () => {
-    testProperties.set("REFFERALS_BUCKET_API_KEY", "");
+  it("should raise an error if REFERRALS_BUCKET_API_KEY property is empty", () => {
+    testProperties.set("REFERRALS_BUCKET_API_KEY", "");
 
     expect(getProperties).toThrow(
-      "Property REFFERALS_BUCKET_API_KEY could not be found"
+      "Property REFERRALS_BUCKET_API_KEY could not be found"
     );
   });
 
@@ -79,11 +79,11 @@ describe.only("#getProperties", () => {
     );
   });
 
-  it("should raise an error if REFFERALS_BUCKET_URL property is null", () => {
-    testProperties.set("REFFERALS_BUCKET_URL", null);
+  it("should raise an error if REFERRALS_BUCKET_URL property is null", () => {
+    testProperties.set("REFERRALS_BUCKET_URL", null);
 
     expect(getProperties).toThrow(
-      "Property REFFERALS_BUCKET_URL could not be found"
+      "Property REFERRALS_BUCKET_URL could not be found"
     );
   });
 
@@ -95,11 +95,11 @@ describe.only("#getProperties", () => {
     );
   });
 
-  it("should raise an error if REFFERALS_BUCKET_API_KEY property is null", () => {
-    testProperties.set("REFFERALS_BUCKET_API_KEY", null);
+  it("should raise an error if REFERRALS_BUCKET_API_KEY property is null", () => {
+    testProperties.set("REFERRALS_BUCKET_API_KEY", null);
 
     expect(getProperties).toThrow(
-      "Property REFFERALS_BUCKET_API_KEY could not be found"
+      "Property REFERRALS_BUCKET_API_KEY could not be found"
     );
   });
 });

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -1,8 +1,10 @@
 import { MockSpreadsheetApp } from "../__mocks__/google_mocks";
 import { onFormSubmit } from "../main";
 import { getProperties } from "../getProperties";
+import { setUniqueIdOnSubmission } from "../setUniqueIdOnSubmission";
 
 jest.mock("../getProperties")
+jest.mock("../setUniqueIdOnSubmission")
 
 describe("#onFormSubmit()", () => {
   let mockFormData: { [key: string]: string[] };
@@ -40,7 +42,9 @@ describe("#onFormSubmit()", () => {
       S3_ENDPOINT_API: "EXAMPLE_S3_URL",
       S3_ENDPOINT_API_KEY: "EXAMPLE_API_KEY",
       FORM_SUBMISSION_ID_COLUMN_POSITION: "1",
-    }))
+    }));
+
+    (setUniqueIdOnSubmission as jest.Mock).mockImplementation(() => { return 1 })
   });
 
   // todo figure out how to make mock of getProperties throw an error
@@ -75,187 +79,34 @@ describe("#onFormSubmit()", () => {
     ).toHaveBeenCalledWith("EXAMPLE_SHEET_NAME");
   });
 
-  it("should return an error if the active sheet is not found", () => {
-    /* 
-    Arrange: Set up mocks and their return values:
-    Explicitly setting the mock to return null, otherwise it will return undefined
-    */
+  it("should log an error when setUniqueIdOnSubmission throws one", () => {
+    const message = "Error";
+    (setUniqueIdOnSubmission as jest.Mock).mockImplementationOnce(() => { throw new Error(message) })
 
-    (
-      MockSpreadsheetApp.mockActiveSpreadsheet.getSheetByName as jest.Mock<null>
-    ).mockImplementation(() => {
-      return null;
-    });
+    onFormSubmit(mockEvent)
 
-    // Act: Trigger event when form is submitted
-    onFormSubmit(mockEvent);
-
-    // Assertion: Logs error message if the sheet is null
-    expect(global.Logger.log).toHaveBeenCalledWith(
-      JSON.stringify(mockEvent.namedValues),
+    expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockEvent.namedValues),
       {
         event: mockEvent,
       },
-      "Sheet by name method returned null or undefined"
-    );
-  });
+      message);
+  })
 
-  it("should log the form data, event & error message when an error occurs", () => {
-    /* 
-    Arrange: Set up mocks and their return values:
-    When not explicitly set, the mocks will return undefined
-    --------------------------------------------------------
-    Arrange: Form submission event and error message
-    */
+  it("should call setUniqueIdOnSubmission with the correct parameters", () => {
+    const mockSetUniqueIdOnSubmission = (setUniqueIdOnSubmission as jest.Mock)
 
-    // Act: Trigger event when form is submitted
-    try {
-      onFormSubmit(mockEvent);
-    } catch (e) { }
+    onFormSubmit(mockEvent)
 
-    // Assertion: Logs error message if the sheet is undefined
-    expect(global.Logger.log).toHaveBeenCalledWith(
-      JSON.stringify(mockEvent.namedValues),
-      {
-        event: mockEvent,
-      },
-      "Sheet by name method returned null or undefined"
-    );
-  });
-
-  it("should get the range for the row above where the form data was submitted", () => {
-    // Arrange: Set up mocks and their return values
-    (
-      MockSpreadsheetApp.mockActiveSpreadsheet
-        .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
-    ).mockImplementation(() => {
-      return MockSpreadsheetApp.mockActiveSheet;
-    });
-
-    // Arrange: Form submission event and spreadsheet cells of interest
-    const currentRowIndex = 7;
-    const previousRowIndex = 6;
-
-    mockEvent = {
-      range: {
-        getRow() {
-          return currentRowIndex;
-        },
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
-
-    // Act: Trigger event when form is submitted
-    onFormSubmit(mockEvent);
-
-    // Assertion: Finds the ID cell of the previous form submission in the sheet
-    expect(MockSpreadsheetApp.mockActiveSheet.getRange).toHaveBeenCalledWith(
-      previousRowIndex,
-      1
-    );
-  });
-
-  it("should get the value of the form ID for the previous form data entry", () => {
-    // Arrange: Set up mocks and their return values
-    (
-      MockSpreadsheetApp.mockActiveSpreadsheet
-        .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
-    ).mockImplementation(() => {
-      return MockSpreadsheetApp.mockActiveSheet;
-    });
-
-    (
-      MockSpreadsheetApp.mockActiveSheet
-        .getRange as jest.Mock<GoogleAppsScript.Spreadsheet.Range>
-    ).mockImplementation(() => {
-      return MockSpreadsheetApp.mockActiveRange;
-    });
-
-    // Act: Trigger event when form is submitted
-    onFormSubmit(mockEvent);
-
-    // Assertion: Retrieves the value of the previous row's ID
-    expect(MockSpreadsheetApp.mockActiveRange.getValue).toHaveBeenCalled();
-  });
-
-  it("should set a next value as the ID for the current form data entry", () => {
-    // Arrange: Set up mocks and their return values
-    (
-      MockSpreadsheetApp.mockActiveSpreadsheet
-        .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
-    ).mockImplementation(() => {
-      return MockSpreadsheetApp.mockActiveSheet;
-    });
-
-    (
-      MockSpreadsheetApp.mockActiveSheet
-        .getRange as jest.Mock<GoogleAppsScript.Spreadsheet.Range>
-    ).mockImplementation(() => {
-      return MockSpreadsheetApp.mockActiveRange;
-    });
-
-    (
-      MockSpreadsheetApp.mockActiveRange.getValue as jest.Mock<number>
-    ).mockImplementation(() => {
-      return previousFormId;
-    });
-
-    // Arrange: Form submission event and spreadsheet cells of interest
-    const currentRow = 11;
-    const previousFormId = 99;
-
-    mockEvent = {
-      range: {
-        getRow() {
-          return currentRow;
-        },
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
-
-    // Act: Trigger event when form is submitted
-    onFormSubmit(mockEvent);
-
-    // Assertion: Generated ID for the form data is inserted into the spreadsheet
-    expect(MockSpreadsheetApp.mockActiveRange.setValue).toHaveBeenCalledWith(
-      100
-    );
-  });
+    expect(mockSetUniqueIdOnSubmission).toBeCalledWith(undefined, "1", mockEvent);
+  })
 
   it("should send the form data with its ID to AWS for further processing", () => {
-    // Arrange: Set up mocks and their return values
-    (
-      MockSpreadsheetApp.mockActiveSpreadsheet
-        .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
-    ).mockImplementation(() => {
-      return MockSpreadsheetApp.mockActiveSheet;
-    });
+    const submissionId = "1"
 
-    (
-      MockSpreadsheetApp.mockActiveSheet
-        .getRange as jest.Mock<GoogleAppsScript.Spreadsheet.Range>
-    ).mockImplementation(() => {
-      return MockSpreadsheetApp.mockActiveRange;
-    });
+    const formDataWithId = mockEvent.namedValues;
+    formDataWithId.FormSubmissionId = [submissionId];
 
-    (
-      MockSpreadsheetApp.mockActiveRange.getValue as jest.Mock<number>
-    ).mockImplementation(() => {
-      return previousFormId;
-    });
-
-    (
-      MockSpreadsheetApp.mockActiveRange
-        .setValue as jest.Mock<GoogleAppsScript.Spreadsheet.Range>
-    ).mockImplementation(() => {
-      return MockSpreadsheetApp.mockActiveRange;
-    });
-
-    // Arrange: Form submission event, HTTP request options and updated form data with generated ID
-    const previousFormId = 99;
-
-    var formDataWithId = mockEvent.namedValues;
-    formDataWithId.FormSubmissionId = ["100"];
-
-    var options = {
+    const options = {
       method: "put",
       headers: { "X-API-KEY": "EXAMPLE_API_KEY" },
       contentType: "application/json",
@@ -267,7 +118,7 @@ describe("#onFormSubmit()", () => {
 
     // Assertion: Form submission data including generated unique ID sent to AWS
     expect(global.UrlFetchApp.fetch).toHaveBeenCalledWith(
-      `EXAMPLE_S3_URL/form-submissions/100`,
+      `EXAMPLE_S3_URL/form-submissions/${submissionId}`,
       options
     );
   });

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -12,15 +12,15 @@ describe("#onFormSubmit()", () => {
       log: jest.fn(),
     } as unknown as GoogleAppsScript.Base.Logger;
 
+    global.PropertiesService =
+      new MockPropertiesService() as unknown as GoogleAppsScript.Properties.PropertiesService;
+
     global.SpreadsheetApp =
       new MockSpreadsheetApp() as unknown as GoogleAppsScript.Spreadsheet.SpreadsheetApp;
 
     global.UrlFetchApp = {
       fetch: jest.fn(),
     } as unknown as GoogleAppsScript.URL_Fetch.UrlFetchApp;
-
-    global.PropertiesService =
-      new MockPropertiesService() as unknown as GoogleAppsScript.Properties.PropertiesService;
   });
 
   it("should get the active sheet for storing the MASH referrals", () => {
@@ -56,8 +56,10 @@ describe("#onFormSubmit()", () => {
   });
 
   it("should return an error if the active sheet is not found", () => {
-    // Arrange: Set up mocks and their return values
-    // Explicitly setting the mock to return null, otherwise it will return undefined
+    /* 
+    Arrange: Set up mocks and their return values:
+    Explicitly setting the mock to return null, otherwise it will return undefined
+    */
 
     (
       MockSpreadsheetApp.mockActiveSpreadsheet.getSheetByName as jest.Mock<null>
@@ -87,10 +89,12 @@ describe("#onFormSubmit()", () => {
   });
 
   it("should log the form data, event & error message when an error occurs", () => {
-    // Arrange: Set up mocks and their return values
-    // When not explicitly setup, the mocks will return undefined
-
-    // Arrange: Form submission event and error message
+    /* 
+    Arrange: Set up mocks and their return values:
+    When not explicitly set, the mocks will return undefined
+    --------------------------------------------------------
+    Arrange: Form submission event and error message
+    */
 
     const sheetNotFoundError = new Error(
       "Sheet by name method returned null or undefined"

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -1,5 +1,4 @@
 import {
-  MockPropertiesService,
   MockSpreadsheetApp,
 } from "../__mocks__/google_mocks";
 import { onFormSubmit } from "../main";
@@ -9,17 +8,8 @@ describe("#onFormSubmit()", () => {
 
   let mockEvent: GoogleAppsScript.Events.SheetsOnFormSubmit;
 
-  let testProperties: Map<string, string>;
-
   beforeEach(() => {
     jest.resetAllMocks();
-
-    testProperties = new Map([
-      ["MASH_SHEET_NAME", "EXAMPLE_SHEET_NAME"],
-      ["REFFERALS_BUCKET_URL", "EXAMPLE_S3_URL"],
-      ["UNIQUE_ID_COLUMN_NO", "1"],
-      ["REFFERALS_BUCKET_API_KEY", "EXAMPLE_API_KEY"],
-    ]);
 
     mockFormData = {
       "First Name": ["Hello"],
@@ -37,9 +27,6 @@ describe("#onFormSubmit()", () => {
       log: jest.fn(),
     } as unknown as GoogleAppsScript.Base.Logger;
 
-    global.PropertiesService =
-      new MockPropertiesService() as unknown as GoogleAppsScript.Properties.PropertiesService;
-
     global.SpreadsheetApp =
       new MockSpreadsheetApp() as unknown as GoogleAppsScript.Spreadsheet.SpreadsheetApp;
 
@@ -47,78 +34,8 @@ describe("#onFormSubmit()", () => {
       fetch: jest.fn(),
     } as unknown as GoogleAppsScript.URL_Fetch.UrlFetchApp;
 
-    (
-      MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
-    ).mockImplementation((a) => {
-      if (testProperties.has(a)) {
-        return testProperties.get(a) as string;
-      }
-      return "";
-    });
-  });
-
-  it("should raise an error if sheet name property is empty", () => {
-    testProperties.set("MASH_SHEET_NAME", "");
-
-    // Act: Trigger event when form is submitted
-    onFormSubmit(mockEvent);
-
-    // Assertion: Logs error message if the sheet is null
-    expect(global.Logger.log).toHaveBeenCalledWith(
-      JSON.stringify(mockFormData),
-      {
-        event: mockEvent,
-      },
-      "Property MASH_SHEET_NAME could not be found"
-    );
-  });
-
-  it("should raise an error if REFFERALS_BUCKET_URL property is empty", () => {
-    testProperties.set("REFFERALS_BUCKET_URL", "");
-
-    // Act: Trigger event when form is submitted
-    onFormSubmit(mockEvent);
-
-    // Assertion: Logs error message if the sheet is null
-    expect(global.Logger.log).toHaveBeenCalledWith(
-      JSON.stringify(mockFormData),
-      {
-        event: mockEvent,
-      },
-      "Property REFFERALS_BUCKET_URL could not be found"
-    );
-  });
-
-  it("should raise an error if UNIQUE_ID_COLUMN_NO property is empty", () => {
-    testProperties.set("UNIQUE_ID_COLUMN_NO", "");
-
-    // Act: Trigger event when form is submitted
-    onFormSubmit(mockEvent);
-
-    // Assertion: Logs error message if the sheet is null
-    expect(global.Logger.log).toHaveBeenCalledWith(
-      JSON.stringify(mockFormData),
-      {
-        event: mockEvent,
-      },
-      "Property UNIQUE_ID_COLUMN_NO could not be found"
-    );
-  });
-
-  it("should raise an error if REFFERALS_BUCKET_API_KEY property is empty", () => {
-    testProperties.set("REFFERALS_BUCKET_API_KEY", "");
-
-    // Act: Trigger event when form is submitted
-    onFormSubmit(mockEvent);
-
-    // Assertion: Logs error message if the sheet is null
-    expect(global.Logger.log).toHaveBeenCalledWith(
-      JSON.stringify(mockFormData),
-      {
-        event: mockEvent,
-      },
-      "Property REFFERALS_BUCKET_API_KEY could not be found"
-    );
+    // mock getProperties 
+    // ^ one test where we we mock an error and expect Logger to be called
   });
 
   it("should get the active sheet for storing the MASH referrals", () => {

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -7,24 +7,21 @@ jest.mock("../getProperties")
 jest.mock("../setUniqueIdOnSubmission")
 
 describe("#onFormSubmit()", () => {
-  let mockFormData: { [key: string]: string[] };
+  
+  const mockFormData = {
+    "First Name": ["Hello"],
+    "Last Name": ["World"],
+  }
 
-  let mockEvent: GoogleAppsScript.Events.SheetsOnFormSubmit;
+  const mockEvent = {
+    namedValues: mockFormData,
+    range: {
+      getRow() { },
+    } as unknown as GoogleAppsScript.Spreadsheet.Range,
+  } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
   beforeEach(() => {
     jest.resetAllMocks();
-
-    mockFormData = {
-      "First Name": ["Hello"],
-      "Last Name": ["World"],
-    };
-
-    mockEvent = {
-      namedValues: mockFormData,
-      range: {
-        getRow() { },
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     global.Logger = {
       log: jest.fn(),
@@ -47,7 +44,6 @@ describe("#onFormSubmit()", () => {
     (setUniqueIdOnSubmission as jest.Mock).mockImplementation(() => { return 1 })
   });
 
-  // todo figure out how to make mock of getProperties throw an error
   it('should log an error when getProperties throws an error', () => {
     const message = "test name";
     (getProperties as jest.Mock).mockImplementationOnce(() => { throw new Error(message) })

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -1,4 +1,7 @@
-import { MockSpreadsheetApp } from "../__mocks__/google_mocks";
+import {
+  MockPropertiesService,
+  MockSpreadsheetApp,
+} from "../__mocks__/google_mocks";
 import { onFormSubmit } from "../main";
 
 describe("#onFormSubmit()", () => {
@@ -15,6 +18,9 @@ describe("#onFormSubmit()", () => {
     global.UrlFetchApp = {
       fetch: jest.fn(),
     } as unknown as GoogleAppsScript.URL_Fetch.UrlFetchApp;
+
+    global.PropertiesService =
+      new MockPropertiesService() as unknown as GoogleAppsScript.Properties.PropertiesService;
   });
 
   it("should get the active sheet for storing the MASH referrals", () => {
@@ -23,6 +29,16 @@ describe("#onFormSubmit()", () => {
         .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
     ).mockImplementation(() => {
       return MockSpreadsheetApp.mockActiveSheet;
+    });
+
+    (
+      MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
+    ).mockImplementation((a) => {
+      if (a === "MASH_SHEET_NAME") {
+        return "EXAMPLE_SHEET_NAME";
+      } else {
+        return "";
+      }
     });
 
     const mockEvent = {
@@ -106,9 +122,18 @@ describe("#onFormSubmit()", () => {
       return MockSpreadsheetApp.mockActiveSheet;
     });
 
+    (
+      MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
+    ).mockImplementation((a) => {
+      if (a === "UNIQUE_ID_COLUMN_NO") {
+        return "1";
+      } else {
+        return "";
+      }
+    });
+
     const currentRow = 7;
     const previousRow = 6;
-    const setFormIdColumn = 1;
 
     const mockEvent = {
       sample: "event",
@@ -123,7 +148,7 @@ describe("#onFormSubmit()", () => {
 
     expect(MockSpreadsheetApp.mockActiveSheet.getRange).toHaveBeenCalledWith(
       previousRow,
-      setFormIdColumn
+      1
     );
   });
 
@@ -195,6 +220,18 @@ describe("#onFormSubmit()", () => {
   });
 
   it("should send the form data with its ID to AWS for further processing", () => {
+    (
+      MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
+    ).mockImplementation((a) => {
+      if (a === "REFFERALS_BUCKET_URL") {
+        return "EXAMPLE_ENDPOINT";
+      } else if (a === "REFFERALS_BUCKET_API_KEY") {
+        return "EXAMPLE_API_KEY";
+      } else {
+        return "";
+      }
+    });
+
     const mockFormSubmission = {
       "First Name": ["Hello"],
       "Last Name": ["World"],

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -14,7 +14,9 @@ describe("#onFormSubmit()", () => {
 
     testProperties = new Map([
       ["MASH_SHEET_NAME", "EXAMPLE_SHEET_NAME"],
-      ["REFFERALS_BUCKET_URL", "EXAMPLE_S3_URL"]
+      ["REFFERALS_BUCKET_URL", "EXAMPLE_S3_URL"],
+      ["UNIQUE_ID_COLUMN_NO", "1"],
+      ["REFFERALS_BUCKET_API_KEY", "EXAMPLE_API_KEY"]
     ]);
 
     global.Logger = {
@@ -91,6 +93,58 @@ describe("#onFormSubmit()", () => {
     expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockFormData), {
       event: mockEvent,
     },"Property REFFERALS_BUCKET_URL could not be found");
+  });
+
+  it("should raise an error if UNIQUE_ID_COLUMN_NO property is empty", () => {
+    testProperties.set("UNIQUE_ID_COLUMN_NO", "")
+
+    // Arrange: Form submission event
+    const mockFormData = {
+      "First Name": ["Hello"],
+      "Last Name": ["World"],
+    };
+
+    const mockEvent = {
+      sample: "event",
+      namedValues: mockFormData,
+      range: {
+        getRow() {},
+      } as unknown as GoogleAppsScript.Spreadsheet.Range,
+    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
+
+    // Act: Trigger event when form is submitted
+    onFormSubmit(mockEvent);
+
+    // Assertion: Logs error message if the sheet is null
+    expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockFormData), {
+      event: mockEvent,
+    },"Property UNIQUE_ID_COLUMN_NO could not be found");
+  });
+
+  it("should raise an error if REFFERALS_BUCKET_API_KEY property is empty", () => {
+    testProperties.set("REFFERALS_BUCKET_API_KEY", "")
+
+    // Arrange: Form submission event
+    const mockFormData = {
+      "First Name": ["Hello"],
+      "Last Name": ["World"],
+    };
+
+    const mockEvent = {
+      sample: "event",
+      namedValues: mockFormData,
+      range: {
+        getRow() {},
+      } as unknown as GoogleAppsScript.Spreadsheet.Range,
+    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
+
+    // Act: Trigger event when form is submitted
+    onFormSubmit(mockEvent);
+
+    // Assertion: Logs error message if the sheet is null
+    expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockFormData), {
+      event: mockEvent,
+    },"Property REFFERALS_BUCKET_API_KEY could not be found");
   });
 
   it("should get the active sheet for storing the MASH referrals", () => {
@@ -190,12 +244,6 @@ describe("#onFormSubmit()", () => {
         .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
     ).mockImplementation(() => {
       return MockSpreadsheetApp.mockActiveSheet;
-    });
-
-    (
-      MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
-    ).mockImplementation((a) => {
-      return a === "UNIQUE_ID_COLUMN_NO" ? `${idColumnIndex}` : "NOT_NULL";
     });
 
     // Arrange: Form submission event and spreadsheet cells of interest

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -6,8 +6,11 @@ import { onFormSubmit } from "../main";
 
 describe("#onFormSubmit()", () => {
 
-  let testProperties: Map<string, string>;
+  let mockFormData:{[key:string]:string[]};
 
+  let mockEvent:GoogleAppsScript.Events.SheetsOnFormSubmit;
+
+  let testProperties: Map<string, string>;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -18,6 +21,18 @@ describe("#onFormSubmit()", () => {
       ["UNIQUE_ID_COLUMN_NO", "1"],
       ["REFFERALS_BUCKET_API_KEY", "EXAMPLE_API_KEY"]
     ]);
+
+    mockFormData = {
+      "First Name": ["Hello"],
+      "Last Name": ["World"],
+    };
+  
+    mockEvent = {
+      namedValues: mockFormData,
+      range: {
+        getRow() {},
+      } as unknown as GoogleAppsScript.Spreadsheet.Range,
+    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     global.Logger = {
       log: jest.fn(),
@@ -46,20 +61,6 @@ describe("#onFormSubmit()", () => {
   it("should raise an error if sheet name property is empty", () => {
     testProperties.set("MASH_SHEET_NAME", "")
 
-    // Arrange: Form submission event
-    const mockFormData = {
-      "First Name": ["Hello"],
-      "Last Name": ["World"],
-    };
-
-    const mockEvent = {
-      sample: "event",
-      namedValues: mockFormData,
-      range: {
-        getRow() {},
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
-
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
@@ -71,20 +72,6 @@ describe("#onFormSubmit()", () => {
 
   it("should raise an error if REFFERALS_BUCKET_URL property is empty", () => {
     testProperties.set("REFFERALS_BUCKET_URL", "")
-
-    // Arrange: Form submission event
-    const mockFormData = {
-      "First Name": ["Hello"],
-      "Last Name": ["World"],
-    };
-
-    const mockEvent = {
-      sample: "event",
-      namedValues: mockFormData,
-      range: {
-        getRow() {},
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
@@ -98,20 +85,6 @@ describe("#onFormSubmit()", () => {
   it("should raise an error if UNIQUE_ID_COLUMN_NO property is empty", () => {
     testProperties.set("UNIQUE_ID_COLUMN_NO", "")
 
-    // Arrange: Form submission event
-    const mockFormData = {
-      "First Name": ["Hello"],
-      "Last Name": ["World"],
-    };
-
-    const mockEvent = {
-      sample: "event",
-      namedValues: mockFormData,
-      range: {
-        getRow() {},
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
-
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
@@ -123,20 +96,6 @@ describe("#onFormSubmit()", () => {
 
   it("should raise an error if REFFERALS_BUCKET_API_KEY property is empty", () => {
     testProperties.set("REFFERALS_BUCKET_API_KEY", "")
-
-    // Arrange: Form submission event
-    const mockFormData = {
-      "First Name": ["Hello"],
-      "Last Name": ["World"],
-    };
-
-    const mockEvent = {
-      sample: "event",
-      namedValues: mockFormData,
-      range: {
-        getRow() {},
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
@@ -155,14 +114,6 @@ describe("#onFormSubmit()", () => {
     ).mockImplementation(() => {
       return MockSpreadsheetApp.mockActiveSheet;
     });
-
-    // Arrange: Form submission event
-    const mockEvent = {
-      sample: "event",
-      range: {
-        getRow() {},
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
@@ -185,14 +136,6 @@ describe("#onFormSubmit()", () => {
       return null;
     });
 
-    // Arrange: Form submission event and error message
-    const mockEvent = {
-      sample: "event",
-      range: {
-        getRow() {},
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
-
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
@@ -209,18 +152,6 @@ describe("#onFormSubmit()", () => {
     --------------------------------------------------------
     Arrange: Form submission event and error message
     */
-    const mockFormSubmission = {
-      "First Name": ["Hello"],
-      "Last Name": ["World"],
-    };
-
-    const mockEvent = {
-      sample: "event",
-      namedValues: mockFormSubmission,
-      range: {
-        getRow() {},
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     // Act: Trigger event when form is submitted
     try {
@@ -249,10 +180,8 @@ describe("#onFormSubmit()", () => {
     // Arrange: Form submission event and spreadsheet cells of interest
     const currentRowIndex = 7;
     const previousRowIndex = 6;
-    const idColumnIndex = 1;
 
-    const mockEvent = {
-      sample: "event",
+    mockEvent = {
       range: {
         getRow() {
           return currentRowIndex;
@@ -285,14 +214,6 @@ describe("#onFormSubmit()", () => {
     ).mockImplementation(() => {
       return MockSpreadsheetApp.mockActiveRange;
     });
-
-    // Arrange: Form submission event
-    const mockEvent = {
-      sample: "event",
-      range: {
-        getRow() {},
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
@@ -327,8 +248,7 @@ describe("#onFormSubmit()", () => {
     const currentRow = 11;
     const previousFormId = 99;
 
-    const mockEvent = {
-      sample: "event",
+    mockEvent = {
       range: {
         getRow() {
           return currentRow;
@@ -376,19 +296,6 @@ describe("#onFormSubmit()", () => {
 
     // Arrange: Form submission event, HTTP request options and updated form data with generated ID
     const previousFormId = 99;
-
-    const mockFormSubmission = {
-      "First Name": ["Hello"],
-      "Last Name": ["World"],
-    };
-
-    const mockEvent = {
-      sample: "event",
-      namedValues: mockFormSubmission,
-      range: {
-        getRow() {},
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     var formDataWithId = mockEvent.namedValues;
     formDataWithId.FormSubmissionId = ["100"];

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -3,20 +3,19 @@ import { onFormSubmit } from "../main";
 import { getProperties } from "../getProperties";
 import { setUniqueIdOnSubmission } from "../setUniqueIdOnSubmission";
 
-jest.mock("../getProperties")
-jest.mock("../setUniqueIdOnSubmission")
+jest.mock("../getProperties");
+jest.mock("../setUniqueIdOnSubmission");
 
 describe("#onFormSubmit()", () => {
-  
   const mockFormData = {
     "First Name": ["Hello"],
     "Last Name": ["World"],
-  }
+  };
 
   const mockEvent = {
     namedValues: mockFormData,
     range: {
-      getRow() { },
+      getRow() {},
     } as unknown as GoogleAppsScript.Spreadsheet.Range,
   } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
@@ -41,21 +40,27 @@ describe("#onFormSubmit()", () => {
       FORM_SUBMISSION_ID_COLUMN_POSITION: "1",
     }));
 
-    (setUniqueIdOnSubmission as jest.Mock).mockImplementation(() => { return 1 })
+    (setUniqueIdOnSubmission as jest.Mock).mockImplementation(() => {
+      return 1;
+    });
   });
 
-  it('should log an error when getProperties throws an error', () => {
+  it("should log an error when getProperties throws an error", () => {
     const message = "test name";
-    (getProperties as jest.Mock).mockImplementationOnce(() => { throw new Error(message) })
+    (getProperties as jest.Mock).mockImplementationOnce(() => {
+      throw new Error(message);
+    });
 
-    onFormSubmit(mockEvent)
+    onFormSubmit(mockEvent);
 
-    expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockEvent.namedValues),
+    expect(global.Logger.log).toHaveBeenCalledWith(
+      JSON.stringify(mockEvent.namedValues),
       {
         event: mockEvent,
       },
-      message);
-  })
+      message
+    );
+  });
 
   it("should get the active sheet for storing the MASH referrals", () => {
     // Arrange: Set up mocks and their return values
@@ -77,27 +82,35 @@ describe("#onFormSubmit()", () => {
 
   it("should log an error when setUniqueIdOnSubmission throws one", () => {
     const message = "Error";
-    (setUniqueIdOnSubmission as jest.Mock).mockImplementationOnce(() => { throw new Error(message) })
+    (setUniqueIdOnSubmission as jest.Mock).mockImplementationOnce(() => {
+      throw new Error(message);
+    });
 
-    onFormSubmit(mockEvent)
+    onFormSubmit(mockEvent);
 
-    expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockEvent.namedValues),
+    expect(global.Logger.log).toHaveBeenCalledWith(
+      JSON.stringify(mockEvent.namedValues),
       {
         event: mockEvent,
       },
-      message);
-  })
+      message
+    );
+  });
 
   it("should call setUniqueIdOnSubmission with the correct parameters", () => {
-    const mockSetUniqueIdOnSubmission = (setUniqueIdOnSubmission as jest.Mock)
+    const mockSetUniqueIdOnSubmission = setUniqueIdOnSubmission as jest.Mock;
 
-    onFormSubmit(mockEvent)
+    onFormSubmit(mockEvent);
 
-    expect(mockSetUniqueIdOnSubmission).toBeCalledWith(undefined, "1", mockEvent);
-  })
+    expect(mockSetUniqueIdOnSubmission).toBeCalledWith(
+      undefined,
+      "1",
+      mockEvent
+    );
+  });
 
   it("should send the form data with its ID to AWS for further processing", () => {
-    const submissionId = "1"
+    const submissionId = "1";
 
     const formDataWithId = mockEvent.namedValues;
     formDataWithId.FormSubmissionId = [submissionId];

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -1,7 +1,15 @@
-import {
-  MockSpreadsheetApp,
-} from "../__mocks__/google_mocks";
+import { MockSpreadsheetApp } from "../__mocks__/google_mocks";
 import { onFormSubmit } from "../main";
+import { getProperties } from "../getProperties";
+
+jest.mock("../getProperties", () => ({
+  getProperties: () => ({
+    REFERRALS_SHEET_NAME: "EXAMPLE_SHEET_NAME",
+    S3_ENDPOINT_API: "EXAMPLE_S3_URL",
+    S3_ENDPOINT_API_KEY: "EXAMPLE_API_KEY",
+    FORM_SUBMISSION_ID_COLUMN_POSITION: "1",
+  })
+}));
 
 describe("#onFormSubmit()", () => {
   let mockFormData: { [key: string]: string[] };
@@ -19,7 +27,7 @@ describe("#onFormSubmit()", () => {
     mockEvent = {
       namedValues: mockFormData,
       range: {
-        getRow() { },
+        getRow() {},
       } as unknown as GoogleAppsScript.Spreadsheet.Range,
     } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
@@ -33,20 +41,12 @@ describe("#onFormSubmit()", () => {
     global.UrlFetchApp = {
       fetch: jest.fn(),
     } as unknown as GoogleAppsScript.URL_Fetch.UrlFetchApp;
-
-    jest.mock("../getProperties", () => {
-      return {
-        default: {
-          REFERRALS_SHEET_NAME: "EXAMPLE_SHEET_NAME",
-          S3_ENDPOINT_API: "TEST1",
-          S3_ENDPOINT_API_KEY: "TEST2",
-          FORM_SUBMISSION_ID_COLUMN_POSITION: "TEST3"
-        }
-      };
-    })
-    // mock getProperties 
-    // ^ one test where we we mock an error and expect Logger to be called
   });
+
+  // todo figure out how to make mock of getProperties throw an error
+  it('should log an error when getProperties throws an error', () => {
+    expect(5*5).toBe(1);
+  })
 
   it("should get the active sheet for storing the MASH referrals", () => {
     // Arrange: Set up mocks and their return values
@@ -102,7 +102,7 @@ describe("#onFormSubmit()", () => {
     // Act: Trigger event when form is submitted
     try {
       onFormSubmit(mockEvent);
-    } catch (e) { }
+    } catch (e) {}
 
     // Assertion: Logs error message if the sheet is undefined
     expect(global.Logger.log).toHaveBeenCalledWith(

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -19,7 +19,7 @@ describe("#onFormSubmit()", () => {
     mockEvent = {
       namedValues: mockFormData,
       range: {
-        getRow() {},
+        getRow() { },
       } as unknown as GoogleAppsScript.Spreadsheet.Range,
     } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
@@ -34,6 +34,16 @@ describe("#onFormSubmit()", () => {
       fetch: jest.fn(),
     } as unknown as GoogleAppsScript.URL_Fetch.UrlFetchApp;
 
+    jest.mock("../getProperties", () => {
+      return {
+        default: {
+          REFERRALS_SHEET_NAME: "EXAMPLE_SHEET_NAME",
+          S3_ENDPOINT_API: "TEST1",
+          S3_ENDPOINT_API_KEY: "TEST2",
+          FORM_SUBMISSION_ID_COLUMN_POSITION: "TEST3"
+        }
+      };
+    })
     // mock getProperties 
     // ^ one test where we we mock an error and expect Logger to be called
   });
@@ -92,7 +102,7 @@ describe("#onFormSubmit()", () => {
     // Act: Trigger event when form is submitted
     try {
       onFormSubmit(mockEvent);
-    } catch (e) {}
+    } catch (e) { }
 
     // Assertion: Logs error message if the sheet is undefined
     expect(global.Logger.log).toHaveBeenCalledWith(

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -5,8 +5,17 @@ import {
 import { onFormSubmit } from "../main";
 
 describe("#onFormSubmit()", () => {
+
+  let testProperties: Map<string, string>;
+
+
   beforeEach(() => {
     jest.resetAllMocks();
+
+    testProperties = new Map([
+      ["MASH_SHEET_NAME", "EXAMPLE_SHEET_NAME"],
+      ["REFFERALS_BUCKET_URL", "EXAMPLE_S3_URL"]
+    ]);
 
     global.Logger = {
       log: jest.fn(),
@@ -25,25 +34,15 @@ describe("#onFormSubmit()", () => {
     (
       MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
     ).mockImplementation((a) => {
-      if(a === "MASH_SHEET_NAME") {
-        return "EXAMPLE_SHEET_NAME"
-      }
-      if (a === "REFFERALS_BUCKET_URL") {
-        return "EXAMPLE_S3_URL";
+      if(testProperties.has(a)) {
+        return testProperties.get(a) as string;
       }
       return "";
     });
   });
 
   it("should raise an error if sheet name property is empty", () => {
-    (
-      MockPropertiesService.mockProperties.getProperty as jest.Mock<string|null>
-    ).mockImplementation((a) => {
-      if(a === "MASH_SHEET_NAME") {
-        return "";
-      }
-      return "";
-    });
+    testProperties.set("MASH_SHEET_NAME", "")
 
     // Arrange: Form submission event
     const mockFormData = {
@@ -69,17 +68,7 @@ describe("#onFormSubmit()", () => {
   });
 
   it("should raise an error if REFFERALS_BUCKET_URL property is empty", () => {
-    (
-      MockPropertiesService.mockProperties.getProperty as jest.Mock<string | null>
-    ).mockImplementation((a) => {
-      if(a === "MASH_SHEET_NAME") {
-        return "EXAMPLE_SHEET_NAME";
-      }
-      if(a === "REFFERALS_BUCKET_URL") {
-        return ""
-      }
-      return "";
-    });
+    testProperties.set("REFFERALS_BUCKET_URL", "")
 
     // Arrange: Form submission event
     const mockFormData = {

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -5,10 +5,9 @@ import {
 import { onFormSubmit } from "../main";
 
 describe("#onFormSubmit()", () => {
+  let mockFormData: { [key: string]: string[] };
 
-  let mockFormData:{[key:string]:string[]};
-
-  let mockEvent:GoogleAppsScript.Events.SheetsOnFormSubmit;
+  let mockEvent: GoogleAppsScript.Events.SheetsOnFormSubmit;
 
   let testProperties: Map<string, string>;
 
@@ -19,14 +18,14 @@ describe("#onFormSubmit()", () => {
       ["MASH_SHEET_NAME", "EXAMPLE_SHEET_NAME"],
       ["REFFERALS_BUCKET_URL", "EXAMPLE_S3_URL"],
       ["UNIQUE_ID_COLUMN_NO", "1"],
-      ["REFFERALS_BUCKET_API_KEY", "EXAMPLE_API_KEY"]
+      ["REFFERALS_BUCKET_API_KEY", "EXAMPLE_API_KEY"],
     ]);
 
     mockFormData = {
       "First Name": ["Hello"],
       "Last Name": ["World"],
     };
-  
+
     mockEvent = {
       namedValues: mockFormData,
       range: {
@@ -51,7 +50,7 @@ describe("#onFormSubmit()", () => {
     (
       MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
     ).mockImplementation((a) => {
-      if(testProperties.has(a)) {
+      if (testProperties.has(a)) {
         return testProperties.get(a) as string;
       }
       return "";
@@ -59,51 +58,67 @@ describe("#onFormSubmit()", () => {
   });
 
   it("should raise an error if sheet name property is empty", () => {
-    testProperties.set("MASH_SHEET_NAME", "")
+    testProperties.set("MASH_SHEET_NAME", "");
 
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
     // Assertion: Logs error message if the sheet is null
-    expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockFormData), {
-      event: mockEvent,
-    },"Property MASH_SHEET_NAME could not be found");
+    expect(global.Logger.log).toHaveBeenCalledWith(
+      JSON.stringify(mockFormData),
+      {
+        event: mockEvent,
+      },
+      "Property MASH_SHEET_NAME could not be found"
+    );
   });
 
   it("should raise an error if REFFERALS_BUCKET_URL property is empty", () => {
-    testProperties.set("REFFERALS_BUCKET_URL", "")
+    testProperties.set("REFFERALS_BUCKET_URL", "");
 
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
     // Assertion: Logs error message if the sheet is null
-    expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockFormData), {
-      event: mockEvent,
-    },"Property REFFERALS_BUCKET_URL could not be found");
+    expect(global.Logger.log).toHaveBeenCalledWith(
+      JSON.stringify(mockFormData),
+      {
+        event: mockEvent,
+      },
+      "Property REFFERALS_BUCKET_URL could not be found"
+    );
   });
 
   it("should raise an error if UNIQUE_ID_COLUMN_NO property is empty", () => {
-    testProperties.set("UNIQUE_ID_COLUMN_NO", "")
+    testProperties.set("UNIQUE_ID_COLUMN_NO", "");
 
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
     // Assertion: Logs error message if the sheet is null
-    expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockFormData), {
-      event: mockEvent,
-    },"Property UNIQUE_ID_COLUMN_NO could not be found");
+    expect(global.Logger.log).toHaveBeenCalledWith(
+      JSON.stringify(mockFormData),
+      {
+        event: mockEvent,
+      },
+      "Property UNIQUE_ID_COLUMN_NO could not be found"
+    );
   });
 
   it("should raise an error if REFFERALS_BUCKET_API_KEY property is empty", () => {
-    testProperties.set("REFFERALS_BUCKET_API_KEY", "")
+    testProperties.set("REFFERALS_BUCKET_API_KEY", "");
 
     // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
     // Assertion: Logs error message if the sheet is null
-    expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockFormData), {
-      event: mockEvent,
-    },"Property REFFERALS_BUCKET_API_KEY could not be found");
+    expect(global.Logger.log).toHaveBeenCalledWith(
+      JSON.stringify(mockFormData),
+      {
+        event: mockEvent,
+      },
+      "Property REFFERALS_BUCKET_API_KEY could not be found"
+    );
   });
 
   it("should get the active sheet for storing the MASH referrals", () => {
@@ -140,9 +155,13 @@ describe("#onFormSubmit()", () => {
     onFormSubmit(mockEvent);
 
     // Assertion: Logs error message if the sheet is null
-    expect(global.Logger.log).toHaveBeenCalledWith(JSON.stringify(mockEvent.namedValues), {
-      event: mockEvent,
-    }, "Sheet by name method returned null or undefined");
+    expect(global.Logger.log).toHaveBeenCalledWith(
+      JSON.stringify(mockEvent.namedValues),
+      {
+        event: mockEvent,
+      },
+      "Sheet by name method returned null or undefined"
+    );
   });
 
   it("should log the form data, event & error message when an error occurs", () => {

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -348,18 +348,6 @@ describe("#onFormSubmit()", () => {
   it("should send the form data with its ID to AWS for further processing", () => {
     // Arrange: Set up mocks and their return values
     (
-      MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
-    ).mockImplementation((a) => {
-      if (a === "REFFERALS_BUCKET_URL") {
-        return "EXAMPLE_ENDPOINT";
-      } else if (a === "REFFERALS_BUCKET_API_KEY") {
-        return "EXAMPLE_API_KEY";
-      } else {
-        return "NOT_NULL";
-      }
-    });
-
-    (
       MockSpreadsheetApp.mockActiveSpreadsheet
         .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
     ).mockImplementation(() => {
@@ -417,7 +405,7 @@ describe("#onFormSubmit()", () => {
 
     // Assertion: Form submission data including generated unique ID sent to AWS
     expect(global.UrlFetchApp.fetch).toHaveBeenCalledWith(
-      `EXAMPLE_ENDPOINT/form-submissions/100`,
+      `EXAMPLE_S3_URL/form-submissions/100`,
       options
     );
   });

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -24,6 +24,7 @@ describe("#onFormSubmit()", () => {
   });
 
   it("should get the active sheet for storing the MASH referrals", () => {
+    // Arrange: Set up mocks and their return values
     (
       MockSpreadsheetApp.mockActiveSpreadsheet
         .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
@@ -34,13 +35,10 @@ describe("#onFormSubmit()", () => {
     (
       MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
     ).mockImplementation((a) => {
-      if (a === "MASH_SHEET_NAME") {
-        return "EXAMPLE_SHEET_NAME";
-      } else {
-        return "";
-      }
+      return a === "MASH_SHEET_NAME" ? "EXAMPLE_SHEET_NAME" : "";
     });
 
+    // Arrange: Form submission event
     const mockEvent = {
       sample: "event",
       range: {
@@ -48,23 +46,26 @@ describe("#onFormSubmit()", () => {
       } as unknown as GoogleAppsScript.Spreadsheet.Range,
     } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
+    // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
+    // Assertion: Gets the active sheet
     expect(
       MockSpreadsheetApp.mockActiveSpreadsheet.getSheetByName
     ).toHaveBeenCalledWith("EXAMPLE_SHEET_NAME");
   });
 
   it("should return an error if the active sheet is not found", () => {
+    // Arrange: Set up mocks and their return values
+    // Explicitly setting the mock to return null, otherwise it will return undefined
+
     (
       MockSpreadsheetApp.mockActiveSpreadsheet.getSheetByName as jest.Mock<null>
     ).mockImplementation(() => {
       return null;
     });
 
-    // Explicitly setting the mock to return null above
-    // as this would always return undefined if the mock is not set up
-
+    // Arrange: Form submission event and error message
     const sheetNotFoundError = new Error(
       "Sheet by name method returned null or undefined"
     );
@@ -77,13 +78,20 @@ describe("#onFormSubmit()", () => {
     } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     try {
+      // Act: Trigger event when form is submitted
       onFormSubmit(mockEvent);
     } catch (e) {
+      // Assertion: Logs error message if the sheet is null
       expect(e).toEqual(sheetNotFoundError);
     }
   });
 
   it("should log the form data, event & error message when an error occurs", () => {
+    // Arrange: Set up mocks and their return values
+    // When not explicitly setup, the mocks will return undefined
+
+    // Arrange: Form submission event and error message
+
     const sheetNotFoundError = new Error(
       "Sheet by name method returned null or undefined"
     );
@@ -101,10 +109,12 @@ describe("#onFormSubmit()", () => {
       } as unknown as GoogleAppsScript.Spreadsheet.Range,
     } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
+    // Act: Trigger event when form is submitted
     try {
       onFormSubmit(mockEvent);
     } catch (e) {}
 
+    // Assertion: Logs error message if the sheet is undefined
     expect(global.Logger.log).toHaveBeenCalledWith(
       JSON.stringify(mockEvent.namedValues),
       {
@@ -115,6 +125,7 @@ describe("#onFormSubmit()", () => {
   });
 
   it("should get the range for the row above where the form data was submitted", () => {
+    // Arrange: Set up mocks and their return values
     (
       MockSpreadsheetApp.mockActiveSpreadsheet
         .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
@@ -125,34 +136,35 @@ describe("#onFormSubmit()", () => {
     (
       MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
     ).mockImplementation((a) => {
-      if (a === "UNIQUE_ID_COLUMN_NO") {
-        return "1";
-      } else {
-        return "";
-      }
+      return a === "UNIQUE_ID_COLUMN_NO" ? `${idColumnIndex}` : "";
     });
 
-    const currentRow = 7;
-    const previousRow = 6;
+    // Arrange: Form submission event and spreadsheet cells of interest
+    const currentRowIndex = 7;
+    const previousRowIndex = 6;
+    const idColumnIndex = 1;
 
     const mockEvent = {
       sample: "event",
       range: {
         getRow() {
-          return currentRow;
+          return currentRowIndex;
         },
       } as unknown as GoogleAppsScript.Spreadsheet.Range,
     } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
+    // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
+    // Assertion: Finds the ID cell of the previous form submission in the sheet
     expect(MockSpreadsheetApp.mockActiveSheet.getRange).toHaveBeenCalledWith(
-      previousRow,
+      previousRowIndex,
       1
     );
   });
 
   it("should get the value of the form ID for the previous form data entry", () => {
+    // Arrange: Set up mocks and their return values
     (
       MockSpreadsheetApp.mockActiveSpreadsheet
         .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
@@ -167,6 +179,7 @@ describe("#onFormSubmit()", () => {
       return MockSpreadsheetApp.mockActiveRange;
     });
 
+    // Arrange: Form submission event
     const mockEvent = {
       sample: "event",
       range: {
@@ -174,24 +187,15 @@ describe("#onFormSubmit()", () => {
       } as unknown as GoogleAppsScript.Spreadsheet.Range,
     } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
+    // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
+    // Assertion: Retrieves the value of the previous row's ID
     expect(MockSpreadsheetApp.mockActiveRange.getValue).toHaveBeenCalled();
   });
 
   it("should set a next value as the ID for the current form data entry", () => {
-    const currentRow = 11;
-    const previousFormId = 99;
-
-    const mockEvent = {
-      sample: "event",
-      range: {
-        getRow() {
-          return currentRow;
-        },
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
-
+    // Arrange: Set up mocks and their return values
     (
       MockSpreadsheetApp.mockActiveSpreadsheet
         .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
@@ -212,14 +216,30 @@ describe("#onFormSubmit()", () => {
       return previousFormId;
     });
 
+    // Arrange: Form submission event and spreadsheet cells of interest
+    const currentRow = 11;
+    const previousFormId = 99;
+
+    const mockEvent = {
+      sample: "event",
+      range: {
+        getRow() {
+          return currentRow;
+        },
+      } as unknown as GoogleAppsScript.Spreadsheet.Range,
+    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
+
+    // Act: Trigger event when form is submitted
     onFormSubmit(mockEvent);
 
+    // Assertion: Generated ID for the form data is inserted into the spreadsheet
     expect(MockSpreadsheetApp.mockActiveRange.setValue).toHaveBeenCalledWith(
       100
     );
   });
 
   it("should send the form data with its ID to AWS for further processing", () => {
+    // Arrange: Set up mocks and their return values
     (
       MockPropertiesService.mockProperties.getProperty as jest.Mock<string>
     ).mockImplementation((a) => {
@@ -231,21 +251,6 @@ describe("#onFormSubmit()", () => {
         return "";
       }
     });
-
-    const mockFormSubmission = {
-      "First Name": ["Hello"],
-      "Last Name": ["World"],
-    };
-
-    const previousFormId = 99;
-
-    const mockEvent = {
-      sample: "event",
-      namedValues: mockFormSubmission,
-      range: {
-        getRow() {},
-      } as unknown as GoogleAppsScript.Spreadsheet.Range,
-    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     (
       MockSpreadsheetApp.mockActiveSpreadsheet
@@ -274,7 +279,21 @@ describe("#onFormSubmit()", () => {
       return MockSpreadsheetApp.mockActiveRange;
     });
 
-    onFormSubmit(mockEvent);
+    // Arrange: Form submission event, HTTP request options and updated form data with generated ID
+    const previousFormId = 99;
+
+    const mockFormSubmission = {
+      "First Name": ["Hello"],
+      "Last Name": ["World"],
+    };
+
+    const mockEvent = {
+      sample: "event",
+      namedValues: mockFormSubmission,
+      range: {
+        getRow() {},
+      } as unknown as GoogleAppsScript.Spreadsheet.Range,
+    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
     var formDataWithId = mockEvent.namedValues;
     formDataWithId.FormSubmissionId = ["100"];
@@ -286,6 +305,10 @@ describe("#onFormSubmit()", () => {
       payload: JSON.stringify(formDataWithId),
     };
 
+    // Act: Trigger event when form is submitted
+    onFormSubmit(mockEvent);
+
+    // Assertion: Form submission data including generated unique ID sent to AWS
     expect(global.UrlFetchApp.fetch).toHaveBeenCalledWith(
       `EXAMPLE_ENDPOINT/form-submissions/100`,
       options

--- a/google-scripts/process-form-submission/__tests__/setUniqueIdOnSubmission.test.ts
+++ b/google-scripts/process-form-submission/__tests__/setUniqueIdOnSubmission.test.ts
@@ -1,0 +1,125 @@
+import { setUniqueIdOnSubmission } from "../setUniqueIdOnSubmission";
+import { MockSpreadsheetApp } from "../__mocks__/google_mocks";
+
+describe("#setUniqueIdOnSubmission", () => {
+    let mockFormData: { [key: string]: string[] };
+
+    let mockEvent: GoogleAppsScript.Events.SheetsOnFormSubmit;
+
+    const idColumn = "1"
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        mockFormData = {
+            "First Name": ["Hello"],
+            "Last Name": ["World"],
+        };
+
+        mockEvent = {
+            namedValues: mockFormData,
+            range: {
+                getRow() { },
+            } as unknown as GoogleAppsScript.Spreadsheet.Range,
+        } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
+
+        global.SpreadsheetApp =
+            new MockSpreadsheetApp() as unknown as GoogleAppsScript.Spreadsheet.SpreadsheetApp;
+
+        (
+            MockSpreadsheetApp.mockActiveSpreadsheet
+                .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
+        ).mockImplementation(() => {
+            return MockSpreadsheetApp.mockActiveSheet;
+        });
+
+        (
+            MockSpreadsheetApp.mockActiveSheet
+                .getRange as jest.Mock<GoogleAppsScript.Spreadsheet.Range>
+        ).mockImplementation(() => {
+            return MockSpreadsheetApp.mockActiveRange;
+        });
+    })
+
+    it("should return the id for the newly added submission", () => {
+        const currentRowIndex = 7;
+        const previousFormId = 1;
+
+        mockEvent = {
+            range: {
+                getRow() {
+                    return currentRowIndex;
+                },
+            } as unknown as GoogleAppsScript.Spreadsheet.Range,
+        } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
+
+        (
+            MockSpreadsheetApp.mockActiveRange.getValue as jest.Mock<number>
+        ).mockImplementation(() => {
+            return previousFormId;
+        });
+
+        const response = setUniqueIdOnSubmission(MockSpreadsheetApp.mockActiveSheet, idColumn, mockEvent)
+
+        expect(response).toBe(2)
+    })
+
+    it("should throw an error if the active sheet is not found", () => {
+        expect(() => setUniqueIdOnSubmission(null, idColumn, mockEvent)).toThrow(
+            "Sheet by name method returned null or undefined"
+        );
+    });
+
+    it("should get the range for the row above where the form data was submitted", () => {
+        const currentRowIndex = 7;
+        const previousRowIndex = 6;
+
+        mockEvent = {
+            range: {
+                getRow() {
+                    return currentRowIndex;
+                },
+            } as unknown as GoogleAppsScript.Spreadsheet.Range,
+        } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
+
+        setUniqueIdOnSubmission(MockSpreadsheetApp.mockActiveSheet, idColumn, mockEvent)
+
+        expect(MockSpreadsheetApp.mockActiveSheet.getRange).toHaveBeenCalledWith(
+            previousRowIndex,
+            1
+        );
+    });
+
+    it("should get the value of the form ID for the previous form data entry", () => {
+        setUniqueIdOnSubmission(MockSpreadsheetApp.mockActiveSheet, idColumn, mockEvent);
+
+        // Assertion: Retrieves the value of the previous row's ID
+        expect(MockSpreadsheetApp.mockActiveRange.getValue).toHaveBeenCalled();
+    });
+
+    it("should set a next value as the ID for the current form data entry", () => {
+        const currentRow = 11;
+        const previousFormId = 1;
+
+        (
+            MockSpreadsheetApp.mockActiveRange.getValue as jest.Mock<number>
+        ).mockImplementation(() => {
+            return previousFormId;
+        });
+
+
+        mockEvent = {
+            range: {
+                getRow() {
+                    return currentRow;
+                },
+            } as unknown as GoogleAppsScript.Spreadsheet.Range,
+        } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
+
+        setUniqueIdOnSubmission(MockSpreadsheetApp.mockActiveSheet, idColumn, mockEvent);
+
+        expect(MockSpreadsheetApp.mockActiveRange.setValue).toHaveBeenCalledWith(
+            2
+        );
+    });
+})

--- a/google-scripts/process-form-submission/__tests__/setUniqueIdOnSubmission.test.ts
+++ b/google-scripts/process-form-submission/__tests__/setUniqueIdOnSubmission.test.ts
@@ -2,124 +2,137 @@ import { setUniqueIdOnSubmission } from "../setUniqueIdOnSubmission";
 import { MockSpreadsheetApp } from "../__mocks__/google_mocks";
 
 describe("#setUniqueIdOnSubmission", () => {
-    let mockFormData: { [key: string]: string[] };
+  let mockFormData: { [key: string]: string[] };
 
-    let mockEvent: GoogleAppsScript.Events.SheetsOnFormSubmit;
+  let mockEvent: GoogleAppsScript.Events.SheetsOnFormSubmit;
 
-    const idColumn = "1"
+  const idColumn = "1";
 
-    beforeEach(() => {
-        jest.resetAllMocks();
+  beforeEach(() => {
+    jest.resetAllMocks();
 
-        mockFormData = {
-            "First Name": ["Hello"],
-            "Last Name": ["World"],
-        };
+    mockFormData = {
+      "First Name": ["Hello"],
+      "Last Name": ["World"],
+    };
 
-        mockEvent = {
-            namedValues: mockFormData,
-            range: {
-                getRow() { },
-            } as unknown as GoogleAppsScript.Spreadsheet.Range,
-        } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
+    mockEvent = {
+      namedValues: mockFormData,
+      range: {
+        getRow() {},
+      } as unknown as GoogleAppsScript.Spreadsheet.Range,
+    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
-        global.SpreadsheetApp =
-            new MockSpreadsheetApp() as unknown as GoogleAppsScript.Spreadsheet.SpreadsheetApp;
+    global.SpreadsheetApp =
+      new MockSpreadsheetApp() as unknown as GoogleAppsScript.Spreadsheet.SpreadsheetApp;
 
-        (
-            MockSpreadsheetApp.mockActiveSpreadsheet
-                .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
-        ).mockImplementation(() => {
-            return MockSpreadsheetApp.mockActiveSheet;
-        });
-
-        (
-            MockSpreadsheetApp.mockActiveSheet
-                .getRange as jest.Mock<GoogleAppsScript.Spreadsheet.Range>
-        ).mockImplementation(() => {
-            return MockSpreadsheetApp.mockActiveRange;
-        });
-    })
-
-    it("should return the id for the newly added submission", () => {
-        const currentRowIndex = 7;
-        const previousFormId = 1;
-
-        mockEvent = {
-            range: {
-                getRow() {
-                    return currentRowIndex;
-                },
-            } as unknown as GoogleAppsScript.Spreadsheet.Range,
-        } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
-
-        (
-            MockSpreadsheetApp.mockActiveRange.getValue as jest.Mock<number>
-        ).mockImplementation(() => {
-            return previousFormId;
-        });
-
-        const response = setUniqueIdOnSubmission(MockSpreadsheetApp.mockActiveSheet, idColumn, mockEvent)
-
-        expect(response).toBe(2)
-    })
-
-    it("should throw an error if the active sheet is not found", () => {
-        expect(() => setUniqueIdOnSubmission(null, idColumn, mockEvent)).toThrow(
-            "Sheet by name method returned null or undefined"
-        );
+    (
+      MockSpreadsheetApp.mockActiveSpreadsheet
+        .getSheetByName as jest.Mock<GoogleAppsScript.Spreadsheet.Sheet>
+    ).mockImplementation(() => {
+      return MockSpreadsheetApp.mockActiveSheet;
     });
 
-    it("should get the range for the row above where the form data was submitted", () => {
-        const currentRowIndex = 7;
-        const previousRowIndex = 6;
+    (
+      MockSpreadsheetApp.mockActiveSheet
+        .getRange as jest.Mock<GoogleAppsScript.Spreadsheet.Range>
+    ).mockImplementation(() => {
+      return MockSpreadsheetApp.mockActiveRange;
+    });
+  });
 
-        mockEvent = {
-            range: {
-                getRow() {
-                    return currentRowIndex;
-                },
-            } as unknown as GoogleAppsScript.Spreadsheet.Range,
-        } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
+  it("should return the id for the newly added submission", () => {
+    const currentRowIndex = 7;
+    const previousFormId = 1;
 
-        setUniqueIdOnSubmission(MockSpreadsheetApp.mockActiveSheet, idColumn, mockEvent)
+    mockEvent = {
+      range: {
+        getRow() {
+          return currentRowIndex;
+        },
+      } as unknown as GoogleAppsScript.Spreadsheet.Range,
+    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
-        expect(MockSpreadsheetApp.mockActiveSheet.getRange).toHaveBeenCalledWith(
-            previousRowIndex,
-            1
-        );
+    (
+      MockSpreadsheetApp.mockActiveRange.getValue as jest.Mock<number>
+    ).mockImplementation(() => {
+      return previousFormId;
     });
 
-    it("should get the value of the form ID for the previous form data entry", () => {
-        setUniqueIdOnSubmission(MockSpreadsheetApp.mockActiveSheet, idColumn, mockEvent);
+    const response = setUniqueIdOnSubmission(
+      MockSpreadsheetApp.mockActiveSheet,
+      idColumn,
+      mockEvent
+    );
 
-        // Assertion: Retrieves the value of the previous row's ID
-        expect(MockSpreadsheetApp.mockActiveRange.getValue).toHaveBeenCalled();
+    expect(response).toBe(2);
+  });
+
+  it("should throw an error if the active sheet is not found", () => {
+    expect(() => setUniqueIdOnSubmission(null, idColumn, mockEvent)).toThrow(
+      "Sheet by name method returned null or undefined"
+    );
+  });
+
+  it("should get the range for the row above where the form data was submitted", () => {
+    const currentRowIndex = 7;
+    const previousRowIndex = 6;
+
+    mockEvent = {
+      range: {
+        getRow() {
+          return currentRowIndex;
+        },
+      } as unknown as GoogleAppsScript.Spreadsheet.Range,
+    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
+
+    setUniqueIdOnSubmission(
+      MockSpreadsheetApp.mockActiveSheet,
+      idColumn,
+      mockEvent
+    );
+
+    expect(MockSpreadsheetApp.mockActiveSheet.getRange).toHaveBeenCalledWith(
+      previousRowIndex,
+      1
+    );
+  });
+
+  it("should get the value of the form ID for the previous form data entry", () => {
+    setUniqueIdOnSubmission(
+      MockSpreadsheetApp.mockActiveSheet,
+      idColumn,
+      mockEvent
+    );
+
+    // Assertion: Retrieves the value of the previous row's ID
+    expect(MockSpreadsheetApp.mockActiveRange.getValue).toHaveBeenCalled();
+  });
+
+  it("should set a next value as the ID for the current form data entry", () => {
+    const currentRow = 11;
+    const previousFormId = 1;
+
+    (
+      MockSpreadsheetApp.mockActiveRange.getValue as jest.Mock<number>
+    ).mockImplementation(() => {
+      return previousFormId;
     });
 
-    it("should set a next value as the ID for the current form data entry", () => {
-        const currentRow = 11;
-        const previousFormId = 1;
+    mockEvent = {
+      range: {
+        getRow() {
+          return currentRow;
+        },
+      } as unknown as GoogleAppsScript.Spreadsheet.Range,
+    } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
-        (
-            MockSpreadsheetApp.mockActiveRange.getValue as jest.Mock<number>
-        ).mockImplementation(() => {
-            return previousFormId;
-        });
+    setUniqueIdOnSubmission(
+      MockSpreadsheetApp.mockActiveSheet,
+      idColumn,
+      mockEvent
+    );
 
-
-        mockEvent = {
-            range: {
-                getRow() {
-                    return currentRow;
-                },
-            } as unknown as GoogleAppsScript.Spreadsheet.Range,
-        } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
-
-        setUniqueIdOnSubmission(MockSpreadsheetApp.mockActiveSheet, idColumn, mockEvent);
-
-        expect(MockSpreadsheetApp.mockActiveRange.setValue).toHaveBeenCalledWith(
-            2
-        );
-    });
-})
+    expect(MockSpreadsheetApp.mockActiveRange.setValue).toHaveBeenCalledWith(2);
+  });
+});

--- a/google-scripts/process-form-submission/getProperties.ts
+++ b/google-scripts/process-form-submission/getProperties.ts
@@ -3,11 +3,11 @@ export function getProperties() {
     PropertiesService.getScriptProperties().getProperty("MASH_SHEET_NAME");
 
   const S3_ENDPOINT_API = PropertiesService.getScriptProperties().getProperty(
-    "REFFERALS_BUCKET_URL"
+    "REFERRALS_BUCKET_URL"
   );
   const S3_ENDPOINT_API_KEY =
     PropertiesService.getScriptProperties().getProperty(
-      "REFFERALS_BUCKET_API_KEY"
+      "REFERRALS_BUCKET_API_KEY"
     );
 
   const FORM_SUBMISSION_ID_COLUMN_POSITION =
@@ -17,13 +17,13 @@ export function getProperties() {
     throw new Error("Property MASH_SHEET_NAME could not be found");
   }
   if (!S3_ENDPOINT_API) {
-    throw new Error("Property REFFERALS_BUCKET_URL could not be found");
+    throw new Error("Property REFERRALS_BUCKET_URL could not be found");
   }
   if (!FORM_SUBMISSION_ID_COLUMN_POSITION) {
     throw new Error("Property UNIQUE_ID_COLUMN_NO could not be found");
   }
   if (!S3_ENDPOINT_API_KEY) {
-    throw new Error("Property REFFERALS_BUCKET_API_KEY could not be found");
+    throw new Error("Property REFERRALS_BUCKET_API_KEY could not be found");
   }
 
   return {

--- a/google-scripts/process-form-submission/getProperties.ts
+++ b/google-scripts/process-form-submission/getProperties.ts
@@ -1,4 +1,4 @@
-export function getProperties() {
+export default function getProperties() {
   const REFERRALS_SHEET_NAME =
     PropertiesService.getScriptProperties().getProperty("MASH_SHEET_NAME");
 

--- a/google-scripts/process-form-submission/getProperties.ts
+++ b/google-scripts/process-form-submission/getProperties.ts
@@ -1,0 +1,35 @@
+export function getProperties() {
+  const REFERRALS_SHEET_NAME =
+    PropertiesService.getScriptProperties().getProperty("MASH_SHEET_NAME");
+
+  const S3_ENDPOINT_API = PropertiesService.getScriptProperties().getProperty(
+    "REFFERALS_BUCKET_URL"
+  );
+  const S3_ENDPOINT_API_KEY =
+    PropertiesService.getScriptProperties().getProperty(
+      "REFFERALS_BUCKET_API_KEY"
+    );
+
+  const FORM_SUBMISSION_ID_COLUMN_POSITION =
+    PropertiesService.getScriptProperties().getProperty("UNIQUE_ID_COLUMN_NO");
+
+  if (!REFERRALS_SHEET_NAME) {
+    throw new Error("Property MASH_SHEET_NAME could not be found");
+  }
+  if (!S3_ENDPOINT_API) {
+    throw new Error("Property REFFERALS_BUCKET_URL could not be found");
+  }
+  if (!FORM_SUBMISSION_ID_COLUMN_POSITION) {
+    throw new Error("Property UNIQUE_ID_COLUMN_NO could not be found");
+  }
+  if (!S3_ENDPOINT_API_KEY) {
+    throw new Error("Property REFFERALS_BUCKET_API_KEY could not be found");
+  }
+
+  return {
+    REFERRALS_SHEET_NAME,
+    S3_ENDPOINT_API,
+    S3_ENDPOINT_API_KEY,
+    FORM_SUBMISSION_ID_COLUMN_POSITION,
+  };
+}

--- a/google-scripts/process-form-submission/getProperties.ts
+++ b/google-scripts/process-form-submission/getProperties.ts
@@ -1,4 +1,4 @@
-export default function getProperties() {
+export function getProperties() {
   const REFERRALS_SHEET_NAME =
     PropertiesService.getScriptProperties().getProperty("MASH_SHEET_NAME");
 

--- a/google-scripts/process-form-submission/getProperties.ts
+++ b/google-scripts/process-form-submission/getProperties.ts
@@ -1,17 +1,10 @@
 export function getProperties() {
-  const REFERRALS_SHEET_NAME =
-    PropertiesService.getScriptProperties().getProperty("MASH_SHEET_NAME");
+  const { getProperty } = PropertiesService.getScriptProperties();
 
-  const S3_ENDPOINT_API = PropertiesService.getScriptProperties().getProperty(
-    "REFERRALS_BUCKET_URL"
-  );
-  const S3_ENDPOINT_API_KEY =
-    PropertiesService.getScriptProperties().getProperty(
-      "REFERRALS_BUCKET_API_KEY"
-    );
-
-  const FORM_SUBMISSION_ID_COLUMN_POSITION =
-    PropertiesService.getScriptProperties().getProperty("UNIQUE_ID_COLUMN_NO");
+  const REFERRALS_SHEET_NAME = getProperty("MASH_SHEET_NAME");
+  const S3_ENDPOINT_API = getProperty("REFERRALS_BUCKET_URL");
+  const S3_ENDPOINT_API_KEY = getProperty("REFERRALS_BUCKET_API_KEY");
+  const FORM_SUBMISSION_ID_COLUMN_POSITION = getProperty("UNIQUE_ID_COLUMN_NO");
 
   if (!REFERRALS_SHEET_NAME) {
     throw new Error("Property MASH_SHEET_NAME could not be found");

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -19,8 +19,11 @@ export function onFormSubmit(
   var formData = event.namedValues;
 
   try {
-    if (REFERRALS_SHEET_NAME === ""){
+    if (!REFERRALS_SHEET_NAME){
       throw new Error("Property MASH_SHEET_NAME could not be found");
+    }
+    if (!S3_ENDPOINT_API) {
+      throw new Error("Property REFFERALS_BUCKET_URL could not be found")
     }
     var referralsSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
       `${REFERRALS_SHEET_NAME}`
@@ -32,7 +35,7 @@ export function onFormSubmit(
 
     // Send updated form submission object to AWS
     sendDataToS3();
-  } catch (e:any) {
+  } catch (e: any) {
     Logger.log(
       JSON.stringify(formData),
       {

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -4,7 +4,7 @@ import { setUniqueIdOnSubmission } from "./setUniqueIdOnSubmission";
 export function onFormSubmit(
   event: GoogleAppsScript.Events.SheetsOnFormSubmit
 ) {
-  var formData = event.namedValues;
+  const formData = event.namedValues;
 
   try {
     const {
@@ -14,7 +14,7 @@ export function onFormSubmit(
       FORM_SUBMISSION_ID_COLUMN_POSITION,
     } = getProperties();
 
-    var referralsSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
+    const referralsSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
       `${REFERRALS_SHEET_NAME}`
     );
 
@@ -36,7 +36,7 @@ export function onFormSubmit(
   }
 
   function sendDataToS3(apiUrl: string, apiKey: string, currentUniqueId: number) {
-    var options = {
+    const options = {
       method: "put",
       headers: { "X-API-KEY": apiKey },
       contentType: "application/json",

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -1,4 +1,4 @@
-import { getProperties } from "./getProperties";
+import getProperties from "./getProperties";
 export function onFormSubmit(
   event: GoogleAppsScript.Events.SheetsOnFormSubmit
 ) {

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -19,6 +19,9 @@ export function onFormSubmit(
   var formData = event.namedValues;
 
   try {
+    if (REFERRALS_SHEET_NAME === ""){
+      throw new Error("Property MASH_SHEET_NAME could not be found");
+    }
     var referralsSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
       `${REFERRALS_SHEET_NAME}`
     );
@@ -29,13 +32,13 @@ export function onFormSubmit(
 
     // Send updated form submission object to AWS
     sendDataToS3();
-  } catch (e) {
+  } catch (e:any) {
     Logger.log(
       JSON.stringify(formData),
       {
         event,
       },
-      e
+      e.message
     );
   }
 

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -1,11 +1,26 @@
-const REFERRALS_SHEET_NAME = "EXAMPLE_SHEET_NAME";
-const S3_ENDPOINT_API = "EXAMPLE_ENDPOINT";
-const S3_ENDPOINT_API_KEY = "EXAMPLE_API_KEY";
-const FORM_SUBMISSION_ID_COLUMN_POSITION = 1;
+// const REFERRALS_SHEET_NAME = "EXAMPLE_SHEET_NAME";
+// const S3_ENDPOINT_API = "EXAMPLE_ENDPOINT";
+// const S3_ENDPOINT_API_KEY = "EXAMPLE_API_KEY";
+// const FORM_SUBMISSION_ID_COLUMN_POSITION = 1;
 
 export function onFormSubmit(
   event: GoogleAppsScript.Events.SheetsOnFormSubmit
 ) {
+  const REFERRALS_SHEET_NAME =
+    PropertiesService.getScriptProperties().getProperty("MASH_SHEET_NAME");
+
+  const S3_ENDPOINT_API = PropertiesService.getScriptProperties().getProperty(
+    "REFFERALS_BUCKET_URL"
+  );
+  const S3_ENDPOINT_API_KEY =
+    PropertiesService.getScriptProperties().getProperty(
+      "REFFERALS_BUCKET_API_KEY"
+    );
+
+  const FORM_SUBMISSION_ID_COLUMN_POSITION = Number(
+    PropertiesService.getScriptProperties().getProperty("UNIQUE_ID_COLUMN_NO")
+  );
+
   var formData = event.namedValues;
   try {
     var referralsSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -1,8 +1,3 @@
-// const REFERRALS_SHEET_NAME = "EXAMPLE_SHEET_NAME";
-// const S3_ENDPOINT_API = "EXAMPLE_ENDPOINT";
-// const S3_ENDPOINT_API_KEY = "EXAMPLE_API_KEY";
-// const FORM_SUBMISSION_ID_COLUMN_POSITION = 1;
-
 export function onFormSubmit(
   event: GoogleAppsScript.Events.SheetsOnFormSubmit
 ) {
@@ -22,6 +17,7 @@ export function onFormSubmit(
   );
 
   var formData = event.namedValues;
+
   try {
     var referralsSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
       `${REFERRALS_SHEET_NAME}`

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -1,44 +1,29 @@
+import { getProperties } from "./getProperties";
 export function onFormSubmit(
   event: GoogleAppsScript.Events.SheetsOnFormSubmit
 ) {
-  const REFERRALS_SHEET_NAME =
-    PropertiesService.getScriptProperties().getProperty("MASH_SHEET_NAME");
-
-  const S3_ENDPOINT_API = PropertiesService.getScriptProperties().getProperty(
-    "REFFERALS_BUCKET_URL"
-  );
-  const S3_ENDPOINT_API_KEY =
-    PropertiesService.getScriptProperties().getProperty(
-      "REFFERALS_BUCKET_API_KEY"
-    );
-    
-  const FORM_SUBMISSION_ID_COLUMN_POSITION = PropertiesService.getScriptProperties().getProperty("UNIQUE_ID_COLUMN_NO");
-
   var formData = event.namedValues;
 
   try {
-    if (!REFERRALS_SHEET_NAME){
-      throw new Error("Property MASH_SHEET_NAME could not be found");
-    }
-    if (!S3_ENDPOINT_API) {
-      throw new Error("Property REFFERALS_BUCKET_URL could not be found")
-    }
-    if (!FORM_SUBMISSION_ID_COLUMN_POSITION) {
-      throw new Error("Property UNIQUE_ID_COLUMN_NO could not be found")
-    }
-    if (!S3_ENDPOINT_API_KEY) {
-      throw new Error("Property REFFERALS_BUCKET_API_KEY could not be found")
-    }
+    const {
+      REFERRALS_SHEET_NAME,
+      S3_ENDPOINT_API,
+      S3_ENDPOINT_API_KEY,
+      FORM_SUBMISSION_ID_COLUMN_POSITION,
+    } = getProperties();
     var referralsSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
       `${REFERRALS_SHEET_NAME}`
     );
-    var currentUniqueId = setUniqueIdOnSubmission(referralsSheet);
+    var currentUniqueId = setUniqueIdOnSubmission(
+      referralsSheet,
+      FORM_SUBMISSION_ID_COLUMN_POSITION
+    );
 
     // Update the form submission object to contain its unique ID
     formData.FormSubmissionId = [`${currentUniqueId}`];
 
     // Send updated form submission object to AWS
-    sendDataToS3();
+    sendDataToS3(S3_ENDPOINT_API, S3_ENDPOINT_API_KEY);
   } catch (e: any) {
     Logger.log(
       JSON.stringify(formData),
@@ -49,22 +34,20 @@ export function onFormSubmit(
     );
   }
 
-  function sendDataToS3() {
+  function sendDataToS3(apiUrl: string, apiKey: string) {
     var options = {
       method: "put",
-      headers: { "X-API-KEY": `${S3_ENDPOINT_API_KEY}` },
+      headers: { "X-API-KEY": apiKey },
       contentType: "application/json",
       payload: JSON.stringify(formData),
     } as GoogleAppsScript.URL_Fetch.URLFetchRequestOptions;
 
-    UrlFetchApp.fetch(
-      `${S3_ENDPOINT_API}/form-submissions/${currentUniqueId}`,
-      options
-    );
+    UrlFetchApp.fetch(`${apiUrl}/form-submissions/${currentUniqueId}`, options);
   }
 
   function setUniqueIdOnSubmission(
-    activeSheet: GoogleAppsScript.Spreadsheet.Sheet | null | undefined
+    activeSheet: GoogleAppsScript.Spreadsheet.Sheet | null | undefined,
+    idColumn: string
   ): number {
     if (activeSheet === undefined || activeSheet === null) {
       throw new Error("Sheet by name method returned null or undefined");
@@ -73,7 +56,7 @@ export function onFormSubmit(
       var previousSubmissionRowPosition = currentFormDataRange.getRow() - 1;
       var previousSubmissionIdCell = activeSheet.getRange(
         previousSubmissionRowPosition,
-        Number(FORM_SUBMISSION_ID_COLUMN_POSITION)
+        Number(idColumn)
       );
 
       var previousSubmissionUniqueId: number =
@@ -82,7 +65,7 @@ export function onFormSubmit(
 
       var currentFormIdCell = activeSheet.getRange(
         currentFormDataRange.getRow(),
-        Number(FORM_SUBMISSION_ID_COLUMN_POSITION)
+        Number(idColumn)
       );
       currentFormIdCell.setValue(currentSubmissionUniqueId);
       return currentSubmissionUniqueId;

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -11,10 +11,8 @@ export function onFormSubmit(
     PropertiesService.getScriptProperties().getProperty(
       "REFFERALS_BUCKET_API_KEY"
     );
-
-  const FORM_SUBMISSION_ID_COLUMN_POSITION = Number(
-    PropertiesService.getScriptProperties().getProperty("UNIQUE_ID_COLUMN_NO")
-  );
+    
+  const FORM_SUBMISSION_ID_COLUMN_POSITION = PropertiesService.getScriptProperties().getProperty("UNIQUE_ID_COLUMN_NO");
 
   var formData = event.namedValues;
 
@@ -24,6 +22,12 @@ export function onFormSubmit(
     }
     if (!S3_ENDPOINT_API) {
       throw new Error("Property REFFERALS_BUCKET_URL could not be found")
+    }
+    if (!FORM_SUBMISSION_ID_COLUMN_POSITION) {
+      throw new Error("Property UNIQUE_ID_COLUMN_NO could not be found")
+    }
+    if (!S3_ENDPOINT_API_KEY) {
+      throw new Error("Property REFFERALS_BUCKET_API_KEY could not be found")
     }
     var referralsSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
       `${REFERRALS_SHEET_NAME}`
@@ -69,7 +73,7 @@ export function onFormSubmit(
       var previousSubmissionRowPosition = currentFormDataRange.getRow() - 1;
       var previousSubmissionIdCell = activeSheet.getRange(
         previousSubmissionRowPosition,
-        FORM_SUBMISSION_ID_COLUMN_POSITION
+        Number(FORM_SUBMISSION_ID_COLUMN_POSITION)
       );
 
       var previousSubmissionUniqueId: number =
@@ -78,7 +82,7 @@ export function onFormSubmit(
 
       var currentFormIdCell = activeSheet.getRange(
         currentFormDataRange.getRow(),
-        FORM_SUBMISSION_ID_COLUMN_POSITION
+        Number(FORM_SUBMISSION_ID_COLUMN_POSITION)
       );
       currentFormIdCell.setValue(currentSubmissionUniqueId);
       return currentSubmissionUniqueId;

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -18,7 +18,11 @@ export function onFormSubmit(
       `${REFERRALS_SHEET_NAME}`
     );
 
-    const currentUniqueId = setUniqueIdOnSubmission(referralsSheet, FORM_SUBMISSION_ID_COLUMN_POSITION, event)
+    const currentUniqueId = setUniqueIdOnSubmission(
+      referralsSheet,
+      FORM_SUBMISSION_ID_COLUMN_POSITION,
+      event
+    );
 
     // Update the form submission object to contain its unique ID
     formData.FormSubmissionId = [currentUniqueId.toString()];
@@ -35,7 +39,11 @@ export function onFormSubmit(
     );
   }
 
-  function sendDataToS3(apiUrl: string, apiKey: string, currentUniqueId: number) {
+  function sendDataToS3(
+    apiUrl: string,
+    apiKey: string,
+    currentUniqueId: number
+  ) {
     const options = {
       method: "put",
       headers: { "X-API-KEY": apiKey },

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -24,9 +24,10 @@ export function onFormSubmit(
     );
     var currentUniqueId = setUniqueIdOnSubmission(referralsSheet);
 
-    // Update object to contain its ID
+    // Update the form submission object to contain its unique ID
     formData.FormSubmissionId = [`${currentUniqueId}`];
 
+    // Send updated form submission object to AWS
     sendDataToS3();
   } catch (e) {
     Logger.log(

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -1,4 +1,4 @@
-import getProperties from "./getProperties";
+import {getProperties} from "./getProperties";
 export function onFormSubmit(
   event: GoogleAppsScript.Events.SheetsOnFormSubmit
 ) {

--- a/google-scripts/process-form-submission/setUniqueIdOnSubmission.ts
+++ b/google-scripts/process-form-submission/setUniqueIdOnSubmission.ts
@@ -1,7 +1,7 @@
 export function setUniqueIdOnSubmission(
   activeSheet: GoogleAppsScript.Spreadsheet.Sheet | null,
   idColumn: string,
-  event: GoogleAppsScript.Events.SheetsOnFormSubmit,
+  event: GoogleAppsScript.Events.SheetsOnFormSubmit
 ): number {
   if (!activeSheet) {
     throw new Error("Sheet by name method returned null or undefined");
@@ -14,7 +14,9 @@ export function setUniqueIdOnSubmission(
     Number(idColumn)
   );
 
-  const previousSubmissionUniqueId = Number(previousSubmissionIdCell.getValue());
+  const previousSubmissionUniqueId = Number(
+    previousSubmissionIdCell.getValue()
+  );
   const currentSubmissionUniqueId = previousSubmissionUniqueId + 1;
 
   const currentFormIdCell = activeSheet.getRange(

--- a/google-scripts/process-form-submission/setUniqueIdOnSubmission.ts
+++ b/google-scripts/process-form-submission/setUniqueIdOnSubmission.ts
@@ -1,0 +1,27 @@
+export function setUniqueIdOnSubmission(
+  activeSheet: GoogleAppsScript.Spreadsheet.Sheet | null,
+  idColumn: string,
+  event: GoogleAppsScript.Events.SheetsOnFormSubmit,
+): number {
+  if (!activeSheet) {
+    throw new Error("Sheet by name method returned null or undefined");
+  }
+
+  const currentFormDataRange = event.range;
+  const previousSubmissionRowPosition = currentFormDataRange.getRow() - 1;
+  const previousSubmissionIdCell = activeSheet.getRange(
+    previousSubmissionRowPosition,
+    Number(idColumn)
+  );
+
+  const previousSubmissionUniqueId = Number(previousSubmissionIdCell.getValue());
+  const currentSubmissionUniqueId = previousSubmissionUniqueId + 1;
+
+  const currentFormIdCell = activeSheet.getRange(
+    currentFormDataRange.getRow(),
+    Number(idColumn)
+  );
+  currentFormIdCell.setValue(currentSubmissionUniqueId);
+
+  return currentSubmissionUniqueId;
+}


### PR DESCRIPTION
We need to be able to setup and access secrets such as the API KEY used to call the AWS S3 API Proxy.

It was suggested that we should be able to use Google's [Properties Service](https://developers.google.com/apps-script/guides/properties) to store and retrieve secrets.

From reading the documentation, it looks like adding a secret is done by calling the Properties Service API with the `setProperties` method, see [here](https://developers.google.com/apps-script/reference/properties/properties#setpropertiesproperties) and the code snippet below.

```
// Sets multiple user properties at once.
var userProperties = PropertiesService.getUserProperties();
var newProperties = {nickname: 'Bob', region: 'US', language: 'EN'};
userProperties.setProperties(newProperties);
```

If that is the case, we might need to add the file manually in the Apps Script editor with the values we need and make sure `clasp` ignores them.

TO DO after merging:
- [ ] Set secrets in Apps Script environment
- [ ] Can we test the code, take data and puts it in AWS. Should we use a temporary URL/S3 bucket setup for testing so that test data doesn't go into the production bucket? 