### PR TITLE
fix: Don't log sensitive data

### DIFF
--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -10,6 +10,7 @@ describe("#onFormSubmit()", () => {
   const mockFormData = {
     "First Name": ["Hello"],
     "Last Name": ["World"],
+    "Timestamp": "06/10/2021 10:53:17"
   };
 
   const mockEvent = {
@@ -54,11 +55,7 @@ describe("#onFormSubmit()", () => {
     onFormSubmit(mockEvent);
 
     expect(global.Logger.log).toHaveBeenCalledWith(
-      JSON.stringify(mockEvent.namedValues),
-      {
-        event: mockEvent,
-      },
-      message
+      JSON.stringify({timeStamp: mockEvent.namedValues.Timestamp, errorMessage: message})
     );
   });
 
@@ -89,11 +86,7 @@ describe("#onFormSubmit()", () => {
     onFormSubmit(mockEvent);
 
     expect(global.Logger.log).toHaveBeenCalledWith(
-      JSON.stringify(mockEvent.namedValues),
-      {
-        event: mockEvent,
-      },
-      message
+      JSON.stringify({timeStamp: mockEvent.namedValues.Timestamp, errorMessage: message})
     );
   });
 

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -10,7 +10,7 @@ describe("#onFormSubmit()", () => {
   const mockFormData = {
     "First Name": ["Hello"],
     "Last Name": ["World"],
-    "Timestamp": "06/10/2021 10:53:17"
+    Timestamp: "06/10/2021 10:53:17",
   };
 
   const mockEvent = {
@@ -55,7 +55,10 @@ describe("#onFormSubmit()", () => {
     onFormSubmit(mockEvent);
 
     expect(global.Logger.log).toHaveBeenCalledWith(
-      JSON.stringify({timeStamp: mockEvent.namedValues.Timestamp, errorMessage: message})
+      JSON.stringify({
+        timeStamp: mockEvent.namedValues.Timestamp,
+        errorMessage: message,
+      })
     );
   });
 
@@ -86,7 +89,10 @@ describe("#onFormSubmit()", () => {
     onFormSubmit(mockEvent);
 
     expect(global.Logger.log).toHaveBeenCalledWith(
-      JSON.stringify({timeStamp: mockEvent.namedValues.Timestamp, errorMessage: message})
+      JSON.stringify({
+        timeStamp: mockEvent.namedValues.Timestamp,
+        errorMessage: message,
+      })
     );
   });
 

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -31,11 +31,7 @@ export function onFormSubmit(
     sendDataToS3(S3_ENDPOINT_API, S3_ENDPOINT_API_KEY, currentUniqueId);
   } catch (e: any) {
     Logger.log(
-      JSON.stringify(formData),
-      {
-        event,
-      },
-      e.message
+      JSON.stringify({timeStamp: formData.Timestamp, errorMessage: e.message})
     );
   }
 

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -31,7 +31,7 @@ export function onFormSubmit(
     sendDataToS3(S3_ENDPOINT_API, S3_ENDPOINT_API_KEY, currentUniqueId);
   } catch (e: any) {
     Logger.log(
-      JSON.stringify({timeStamp: formData.Timestamp, errorMessage: e.message})
+      JSON.stringify({ timeStamp: formData.Timestamp, errorMessage: e.message })
     );
   }
 


### PR DESCRIPTION
Reduce the amount of data being logged, no longer log the form data as this could be sensitive information. Just log a timestamp and error message.