### PR TITLE
Refactor: Update node executor docker image to use latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: circleci/node:14.15.5
+      - image: cimg/node:14.18.0
   docker-python:
     docker:
       - image: circleci/python:3.7  


### PR DESCRIPTION
### What
This PR updates the `node-executor` docker image from `circleci/node:14.15.5` to `cimg/node:14.18.0`
### Why
The docker image we were using has become a legacy image and as such is out of date. The image it is being updated to uses the latest version of node and the image itself is designed to supersede the legacy image currently in use.

### Anything else?
A number of hackney repositories which include a `node-executor` still use the legacy image. If the entire workflow is successful with the latest image it is recommended that these repos should have their images updated.