### PR TITLE
Fix: Add aws profiles to new config file

### DIFF
--- a/.circleci/config
+++ b/.circleci/config
@@ -1,0 +1,7 @@
+[default]
+region = eu-west-2
+output = json
+
+[profile circlecitest]
+region = eu-west-2
+output = json


### PR DESCRIPTION
### What
This PR adds the config file which includes certain information such as the aws region for when the pipeline assumes a role on the AWS account
### Why
To fix the pipeline as the job `assume-role-mosaic-production` requires the config to exist