### PR TITLE
Fix: Add correct directory for pipeline deployment job to run in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
 
   deploy-lambda:
      executor: aws-cli/default
+     working_directory: './referral-form-data-process'
      steps:
       - *attach_workspace
       - run:


### PR DESCRIPTION
### What
This PR adds the `working_directory` key to the `deploy-lambda` job
### Why
To deploy the lambda using serverless the pipeline needs to be able to find the `serverless.yml` file. The pipeline defaults to the root of the application when trying to find the file but for this repo this file exists within the `referral-form-data-process` folder instead.