### PR TITLE
fix: Update working directory name for the lambda deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
 
   deploy-lambda:
     executor: aws-cli/default
-    working_directory: "./referral-form-data-process"
+    working_directory: ~/project/referral-form-data-process
     steps:
       - *attach_workspace
       - run:


### PR DESCRIPTION
The deploy-lambda job currently fails [here](https://app.circleci.com/pipelines/github/LBHackney-IT/social-care-referral-form-ingestion/165/workflows/818bb0d6-c336-4739-9848-4b76203c8a18/jobs/579/parallel-runs/0/steps/0-101).

This is an attempt to fix by changing the working directory in the job to match the format of other jobs that passed.