### PR TITLE
Fix: Remove clasp push dependency for deploying lambda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,6 @@ workflows:
       - permit-deploy-production:
           type: approval
           requires:
-            - clasp-push
             - unit-tests-lambda
           filters:
             branches:


### PR DESCRIPTION
We're getting an [error](https://app.circleci.com/pipelines/github/LBHackney-IT/social-care-referral-form-ingestion/167/workflows/48471683-b67e-4953-bf1d-04ace7a87fcc/jobs/592) in the pipeline at the deploy lambda stage. Looking at the logs, it looks like some files from the Apps Script are being persisted at the point where we want to deploy the lambda.

This may not fix the above error but perhaps we want the workflow for the Apps Script code and Lambda to deploy separately. Each has their own dependencies not sure how to combine them into one job or if it's better to keep the workflows apart.

Open to suggestions, feedback, etc.