### PR TITLE
chore(SCT-1357): Add iam role to allow the lambda to get an object from S3

### DIFF
--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -5,6 +5,18 @@ provider:
   runtime: nodejs14.x
   region: eu-west-2
   lambdaHashingVersion: 20201221
+  iam:
+    role:
+      statements:
+        - Effect: "Allow"
+          Action:
+            - "s3:GetObject"
+          Resource:
+            Fn::Join:
+              - ""
+              - - "arn:aws:s3:::"
+                - "social-care-referrals-bucket"
+                - "/*"
 
 functions:
   main:


### PR DESCRIPTION
This adds config for serverless to add an iam role to the lambda that would allow it to only get objects from S3.

Without this permission, the lambda errors with an access denied message when it attempts to get and read the object from S3. We tested this using the `devscratch` account.