### PR TITLE
chore(SCT-1356): Rename lambda file and main function

### DIFF
--- a/referral-form-data-process/handler.ts
+++ b/referral-form-data-process/handler.ts
@@ -1,3 +1,0 @@
-import { SQSEvent } from "aws-lambda";
-
-export const main = async (sqsEvent: SQSEvent) => {};

--- a/referral-form-data-process/main.test.ts
+++ b/referral-form-data-process/main.test.ts
@@ -1,3 +1,3 @@
-describe("#main", () => {
+describe("#handler", () => {
   it("it should do something", () => {});
 });

--- a/referral-form-data-process/main.ts
+++ b/referral-form-data-process/main.ts
@@ -1,0 +1,3 @@
+import { SQSEvent } from "aws-lambda";
+
+export const handler = async (sqsEvent: SQSEvent) => {};

--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -23,7 +23,7 @@ functions:
     environment:
       CLIENTEMAIL: ${opt:CLIENTEMAIL}
       PRIVATEKEY: ${opt:PRIVATEKEY}
-    handler: handler.main
+    handler: referral-form-data-process/main.handler
     events:
       - sqs:
           arn:


### PR DESCRIPTION
This changes the name of the lambda file to `main` and the main function to `handler`.

This also update the `serverless` config to find the lambda file.

When we tested this code in `devscratch` we got errors such as:

- `Runtime.ImportModuleError: Error: Cannot find module`
- `handler is undefined or not exported`

Troubleshooting in the `devscratch` led us to try renaming the function and file based on what AWS would generate if you created the lambda in the console.

But we've come to understand that it was probably our `serverless` and file system setup that was not allowing the lambda to be found during the `devscratch` test.

This makes changes based on what we found from testing in a different environment and how it might apply here.

Any feedback/suggestions are welcome 🙏 