### PR TITLE
Chore(SCT-1365): Compile lambda code into javascript before deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
           command: yarn lint
       - run:
           name: Run tests
-          command: yarn test
+          command: yarn test --runInBand
     environment:
       TZ: "Europe/London"
 


### PR DESCRIPTION
Before we deploy our lambda, we need to compile it from Typescript to Javascript.

This adds a command in the deploy lambda stage to compile the lambda.

Running the compile command will compile the main lambda code as well as the imported file from the lib folder.