### PR TITLE
Fix(SCT-1365): Add fixes from testing lambda in test environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - *attach_workspace
       - run:
           name: "deploy"
-          command: "sudo npm i -g serverless && sls deploy -s mosaic-prod --CLIENTEMAIL $CLIENT_EMAIL --PRIVATEKEY $PRIVATE_KEY"
+          command: "sudo npm i -g serverless && sls deploy -s mosaic-prod --CLIENT_EMAIL $CLIENT_EMAIL --PRIVATE_KEY $PRIVATE_KEY --TEMPLATE_DOCUMENT_ID $TEMPLATE_DOCUMENT_ID --TITLE $TITLE"
 
 workflows:
   version: 2

--- a/referral-form-data-process/main.test.ts
+++ b/referral-form-data-process/main.test.ts
@@ -54,9 +54,9 @@ describe("#handler", () => {
       return {};
     });
 
-    process.env.CLIENTEMAIL = testEmail;
-    process.env.PRIVATEKEY = testKey;
-    process.env.TEMPLATEDOCUMENTID = testTemplateId;
+    process.env.CLIENT_EMAIL = testEmail;
+    process.env.PRIVATE_KEY = testKey;
+    process.env.TEMPLATE_DOCUMENT_ID = testTemplateId;
     process.env.TITLE = testTitle;
   });
 

--- a/referral-form-data-process/main.ts
+++ b/referral-form-data-process/main.ts
@@ -14,17 +14,13 @@ export const handler = async (sqsEvent: SQSEvent) => {
   const googleAuthToken = await generateAuth(clientEmail, formattedPrivateKey);
 
   await Promise.all(
-    formDataObjects.map(async (formData) => {
-      await new Promise((resolve) => {
-        resolve(
-          createDocumentFromTemplate(
-            googleAuthToken,
-            templateDocumentId,
-            title,
-            formData
-          )
-        );
-      });
-    })
+    formDataObjects.map((formData) =>
+      createDocumentFromTemplate(
+        googleAuthToken,
+        templateDocumentId,
+        title,
+        formData
+      )
+    )
   );
 };

--- a/referral-form-data-process/main.ts
+++ b/referral-form-data-process/main.ts
@@ -4,9 +4,9 @@ import { generateAuth } from "./lib/generateGoogleAuth";
 import { getDataFromS3 } from "./lib/getDataFromS3";
 
 export const handler = async (sqsEvent: SQSEvent) => {
-  const clientEmail = process.env.CLIENTEMAIL as string;
-  const privateKey = process.env.PRIVATEKEY as string;
-  const templateDocumentId = process.env.TEMPLATEDOCUMENTID as string;
+  const clientEmail = process.env.CLIENT_EMAIL as string;
+  const privateKey = process.env.PRIVATE_KEY as string;
+  const templateDocumentId = process.env.TEMPLATE_DOCUMENT_ID as string;
   const title = process.env.TITLE as string;
   const formattedPrivateKey = privateKey.replace(/\\n/g, "\n");
 

--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -5,6 +5,7 @@ provider:
   runtime: nodejs14.x
   region: eu-west-2
   lambdaHashingVersion: 20201221
+  timeout: 30
   iam:
     role:
       statements:
@@ -23,6 +24,8 @@ functions:
     environment:
       CLIENTEMAIL: ${opt:CLIENTEMAIL}
       PRIVATEKEY: ${opt:PRIVATEKEY}
+      TEMPLATEDOCUMENTID: ${opt:TEMPLATEDOCUMENTID}
+      TITLE: ${opt:TITLE}
     handler: referral-form-data-process/main.handler
     events:
       - sqs:

--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -5,7 +5,6 @@ provider:
   runtime: nodejs14.x
   region: eu-west-2
   lambdaHashingVersion: 20201221
-  timeout: 30
   iam:
     role:
       statements:

--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -22,9 +22,9 @@ provider:
 functions:
   main:
     environment:
-      CLIENTEMAIL: ${opt:CLIENTEMAIL}
-      PRIVATEKEY: ${opt:PRIVATEKEY}
-      TEMPLATEDOCUMENTID: ${opt:TEMPLATEDOCUMENTID}
+      CLIENT_EMAIL: ${opt:CLIENT_EMAIL}
+      PRIVATE_KEY: ${opt:PRIVATE_KEY}
+      TEMPLATE_DOCUMENT_ID: ${opt:TEMPLATE_DOCUMENT_ID}
       TITLE: ${opt:TITLE}
     handler: referral-form-data-process/main.handler
     events:


### PR DESCRIPTION
This adds the following changes:

1. Format private key
This formats the private key of the service account. The reason for this is because when adding the key to the environment variables it does not format the new line characters and the auth fails.

2. Add `Promise.all`
This encapsulates the code that loops through each form data object within a Promise.all. This means that the code will wait for all the await functions to resolve before exiting the lambda. Without these, the lambda doesn't wait for the entire doc generation to finish and exits prematurely.

3. Add timeout of 30 seconds to the lambda.
The default timeout is 6 seconds. This updates it so that the lambda is up for 30 seconds before terminating itself.