### PR TITLE
Fix(SCT-1489): Change executor for deploy lambda job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           paths: .
 
   deploy-lambda:
-    executor: aws-cli/default
+    executor: node-executor
     working_directory: ~/project/referral-form-data-process
     steps:
       - *attach_workspace


### PR DESCRIPTION
The job currently fails with this yarn [error](https://app.circleci.com/pipelines/github/LBHackney-IT/social-care-referral-form-ingestion/219/workflows/28062245-6d1e-4f98-8309-316c70552899/jobs/878/parallel-runs/0/steps/0-102): `@social-care-referral-form-ingestion/referral-form-data-process@1.0.0: The engine "node" is incompatible with this module. Expected version ">=14.18.0". Got "14.17.5"`

We've come across this before error and I think when we use `aws-cli/default` as the executor, the version of node it has does not match our node engine requirements.