### PR TITLE
Feat(SCT-1012): Update spreadsheet with newly generated Google Doc link

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - *attach_workspace
       - run:
           name: "deploy"
-          command: "yarn deploy -s mosaic-prod --CLIENT_EMAIL $CLIENT_EMAIL --PRIVATE_KEY $PRIVATE_KEY --TEMPLATE_DOCUMENT_ID $TEMPLATE_DOCUMENT_ID --TITLE $TITLE"
+          command: "yarn deploy -s mosaic-prod --CLIENT_EMAIL $CLIENT_EMAIL --PRIVATE_KEY $PRIVATE_KEY --TEMPLATE_DOCUMENT_ID $TEMPLATE_DOCUMENT_ID --TITLE $TITLE --URL_COLUMN $URL_COLUMN --SPREADSHEET_ID $SPREADSHEET_ID"
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project processes the data submitted via the MASH (Multi agency Safeguardin
     - [Brainstorming the new process design](#brainstorming-the-new-process-design)
     - [Google Authentication](#google-authentication)
   - [Deployments](#deployments)
+  - [Environment Variables](#environment-variables)
     - [How to configure CircleCI for automated deployment of our appscript](#how-to-configure-circleci-for-automated-deployment-of-our-appscript)
   - [Troubleshooting](#troubleshooting)
     - [Clasp push suddenly stops working](#clasp-push-suddenly-stops-working)
@@ -79,6 +80,10 @@ The lambda which creates a new google doc and inserts it into the spreadsheet re
     1. CLIENT_EMAIL -- the email associated with the Google Service account
     2. PRIVATE_KEY  -- the private key of the Google Service account
     3. CLASP_REFRESH_TOKEN -- the refresh token to authenticate Clasp with Google
+    4. SPREADSHEET_ID -- the id of google spreadsheet that we update
+    5. TEMPLATE_DOCUMENT_ID -- the id of google doc we use as a template for creating new documents
+    6. URL_COLUMN -- column that contains the URLs to to created google documents
+    7. TITLE -- title of the document
 
 ### How to configure CircleCI for automated deployment of our appscript
 

--- a/google-scripts/process-form-submission/__mocks__/google_mocks.ts
+++ b/google-scripts/process-form-submission/__mocks__/google_mocks.ts
@@ -10,6 +10,7 @@ export class MockSpreadsheetApp {
   static mockActiveRange = {
     getValue: jest.fn(),
     setValue: jest.fn(),
+    getRow: jest.fn(),
   } as unknown as GoogleAppsScript.Spreadsheet.Range;
 
   getActiveSpreadsheet() {

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -111,13 +111,13 @@ describe("#onFormSubmit()", () => {
     );
   });
 
-  it("should send the form data with its ID to AWS for further processing", () => {
+  it("should send the form data with its ID & spreadsheet row to AWS for further processing", () => {
     const submissionId = "1";
-    const formRow = "1";
+    const rowPosition = "1";
 
     const formDataWithId = mockEvent.namedValues;
     formDataWithId.FormSubmissionId = [submissionId];
-    formDataWithId.FormRow = [formRow];
+    formDataWithId.SubmissionRowPosition = [rowPosition];
 
     const options = {
       method: "put",

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -19,7 +19,7 @@ describe("#onFormSubmit()", () => {
   const mockEvent = {
     namedValues: mockFormData,
     range: {
-      getRow() { },
+      getRow() {},
     } as unknown as GoogleAppsScript.Spreadsheet.Range,
   } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 

--- a/google-scripts/process-form-submission/__tests__/main.test.ts
+++ b/google-scripts/process-form-submission/__tests__/main.test.ts
@@ -19,7 +19,7 @@ describe("#onFormSubmit()", () => {
   const mockEvent = {
     namedValues: mockFormData,
     range: {
-      getRow() {},
+      getRow() { },
     } as unknown as GoogleAppsScript.Spreadsheet.Range,
   } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
@@ -45,7 +45,7 @@ describe("#onFormSubmit()", () => {
     }));
 
     (setUniqueIdOnSubmission as jest.Mock).mockImplementation(() => {
-      return 1;
+      return { id: 1, row: 1 };
     });
   });
 
@@ -113,9 +113,11 @@ describe("#onFormSubmit()", () => {
 
   it("should send the form data with its ID to AWS for further processing", () => {
     const submissionId = "1";
+    const formRow = "1";
 
     const formDataWithId = mockEvent.namedValues;
     formDataWithId.FormSubmissionId = [submissionId];
+    formDataWithId.FormRow = [formRow];
 
     const options = {
       method: "put",

--- a/google-scripts/process-form-submission/__tests__/setUniqueIdOnSubmission.test.ts
+++ b/google-scripts/process-form-submission/__tests__/setUniqueIdOnSubmission.test.ts
@@ -41,7 +41,7 @@ describe("#setUniqueIdOnSubmission", () => {
     });
   });
 
-  it("should return the id for the newly added submission", () => {
+  it("should return an object containing the id and spreadsheet row for the newly added submission", () => {
     const currentRowIndex = 7;
     const previousFormId = 1;
 

--- a/google-scripts/process-form-submission/__tests__/setUniqueIdOnSubmission.test.ts
+++ b/google-scripts/process-form-submission/__tests__/setUniqueIdOnSubmission.test.ts
@@ -19,7 +19,7 @@ describe("#setUniqueIdOnSubmission", () => {
     mockEvent = {
       namedValues: mockFormData,
       range: {
-        getRow() {},
+        getRow() { },
       } as unknown as GoogleAppsScript.Spreadsheet.Range,
     } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
@@ -39,11 +39,20 @@ describe("#setUniqueIdOnSubmission", () => {
     ).mockImplementation(() => {
       return MockSpreadsheetApp.mockActiveRange;
     });
+
+
   });
 
   it("should return the id for the newly added submission", () => {
     const currentRowIndex = 7;
     const previousFormId = 1;
+
+    (
+      MockSpreadsheetApp.mockActiveRange
+        .getRow as jest.Mock<number>
+    ).mockImplementation(() => {
+      return currentRowIndex;
+    });
 
     mockEvent = {
       range: {
@@ -65,7 +74,7 @@ describe("#setUniqueIdOnSubmission", () => {
       mockEvent
     );
 
-    expect(response).toBe(2);
+    expect(response).toStrictEqual({ id: 2, row: 7 });
   });
 
   it("should throw an error if the active sheet is not found", () => {

--- a/google-scripts/process-form-submission/__tests__/setUniqueIdOnSubmission.test.ts
+++ b/google-scripts/process-form-submission/__tests__/setUniqueIdOnSubmission.test.ts
@@ -19,7 +19,7 @@ describe("#setUniqueIdOnSubmission", () => {
     mockEvent = {
       namedValues: mockFormData,
       range: {
-        getRow() { },
+        getRow() {},
       } as unknown as GoogleAppsScript.Spreadsheet.Range,
     } as unknown as GoogleAppsScript.Events.SheetsOnFormSubmit;
 
@@ -39,8 +39,6 @@ describe("#setUniqueIdOnSubmission", () => {
     ).mockImplementation(() => {
       return MockSpreadsheetApp.mockActiveRange;
     });
-
-
   });
 
   it("should return the id for the newly added submission", () => {
@@ -48,8 +46,7 @@ describe("#setUniqueIdOnSubmission", () => {
     const previousFormId = 1;
 
     (
-      MockSpreadsheetApp.mockActiveRange
-        .getRow as jest.Mock<number>
+      MockSpreadsheetApp.mockActiveRange.getRow as jest.Mock<number>
     ).mockImplementation(() => {
       return currentRowIndex;
     });

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -18,17 +18,19 @@ export function onFormSubmit(
       `${REFERRALS_SHEET_NAME}`
     );
 
-    const currentUniqueId = setUniqueIdOnSubmission(
+    const currentUniqueSubmissionDetails = setUniqueIdOnSubmission(
       referralsSheet,
       FORM_SUBMISSION_ID_COLUMN_POSITION,
       event
     );
 
+    const uniqueId = currentUniqueSubmissionDetails.id;
+    const formRow = currentUniqueSubmissionDetails.row;
     // Update the form submission object to contain its unique ID
-    formData.FormSubmissionId = [currentUniqueId.toString()];
-
+    formData.FormSubmissionId = [uniqueId.toString()];
+    formData.FormRow = [formRow.toString()];
     // Send updated form submission object to AWS
-    sendDataToS3(S3_ENDPOINT_API, S3_ENDPOINT_API_KEY, currentUniqueId);
+    sendDataToS3(S3_ENDPOINT_API, S3_ENDPOINT_API_KEY, uniqueId);
   } catch (e: any) {
     Logger.log(
       JSON.stringify({

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -26,7 +26,7 @@ export function onFormSubmit(
 
     const uniqueId = currentUniqueSubmissionDetails.id;
     const formRow = currentUniqueSubmissionDetails.row;
-    // Update the form submission object to contain its unique ID
+    // Update the form submission object to contain its unique ID & spreadsheet row
     formData.FormSubmissionId = [uniqueId.toString()];
     formData.FormRow = [formRow.toString()];
     // Send updated form submission object to AWS

--- a/google-scripts/process-form-submission/main.ts
+++ b/google-scripts/process-form-submission/main.ts
@@ -18,17 +18,17 @@ export function onFormSubmit(
       `${REFERRALS_SHEET_NAME}`
     );
 
-    const currentUniqueSubmissionDetails = setUniqueIdOnSubmission(
+    const currentSubmissionDetails = setUniqueIdOnSubmission(
       referralsSheet,
       FORM_SUBMISSION_ID_COLUMN_POSITION,
       event
     );
 
-    const uniqueId = currentUniqueSubmissionDetails.id;
-    const formRow = currentUniqueSubmissionDetails.row;
+    const uniqueId = currentSubmissionDetails.id;
+    const rowPosition = currentSubmissionDetails.row;
     // Update the form submission object to contain its unique ID & spreadsheet row
     formData.FormSubmissionId = [uniqueId.toString()];
-    formData.FormRow = [formRow.toString()];
+    formData.SubmissionRowPosition = [rowPosition.toString()];
     // Send updated form submission object to AWS
     sendDataToS3(S3_ENDPOINT_API, S3_ENDPOINT_API_KEY, uniqueId);
   } catch (e: any) {

--- a/google-scripts/process-form-submission/setUniqueIdOnSubmission.ts
+++ b/google-scripts/process-form-submission/setUniqueIdOnSubmission.ts
@@ -2,7 +2,7 @@ export function setUniqueIdOnSubmission(
   activeSheet: GoogleAppsScript.Spreadsheet.Sheet | null,
   idColumn: string,
   event: GoogleAppsScript.Events.SheetsOnFormSubmit
-): number {
+): Record<string, number> {
   if (!activeSheet) {
     throw new Error("Sheet by name method returned null or undefined");
   }
@@ -25,5 +25,5 @@ export function setUniqueIdOnSubmission(
   );
   currentFormIdCell.setValue(currentSubmissionUniqueId);
 
-  return currentSubmissionUniqueId;
+  return { id: currentSubmissionUniqueId, row: currentFormIdCell.getRow() };
 }

--- a/referral-form-data-process/lib/addGoogleDocUrlToSheet.test.ts
+++ b/referral-form-data-process/lib/addGoogleDocUrlToSheet.test.ts
@@ -1,0 +1,170 @@
+import { OAuth2Client } from "google-auth-library";
+import { google } from "googleapis";
+import { addGoogleDocUrlToSheet } from "./addGoogleDocUrlToSheet";
+
+const mockGet = jest.fn();
+const mockUpdate = jest.fn();
+
+jest.mock("googleapis");
+
+describe.only("#addGoogleDocUrlToSheet", () => {
+    const mockAuth = {
+        credentials: {
+            access_token: "actoken",
+            refresh_token: "rtoken",
+            scope: "https://www.googleapis.com/auth/drive.metadata.readonly",
+            token_type: "Bearer",
+            expiry_date: "1633950562052",
+        },
+    } as unknown as OAuth2Client;
+
+    const testDocumentUrl = "test-document-url";
+    const testColumnUrl = "test-column-url";
+    const testTableRow = "test-table-row";
+    const testSpreadsheetId = "test-spreadsheet-id";
+    const googleSheetVersion = "v4";
+
+    beforeEach(() => {
+        (google.sheets as jest.Mock).mockImplementation(() => ({
+            spreadsheets: {
+                get: mockGet,
+                values: {
+                    update: mockUpdate,
+                },
+            },
+        }));
+
+        mockGet.mockImplementation(() => ({
+            data: {
+                spreadsheetId: testSpreadsheetId,
+            },
+        }));
+    });
+
+    it("should call to sheets with our auth token", async () => {
+        await addGoogleDocUrlToSheet(
+            mockAuth,
+            testDocumentUrl,
+            testColumnUrl,
+            testTableRow
+        );
+
+        expect(google.sheets).toBeCalledWith({
+            version: googleSheetVersion,
+            auth: mockAuth,
+        });
+    });
+
+    it("should throw an error if sheet is undefined", async () => {
+        mockGet.mockImplementation(() => ({
+            data: undefined,
+        }));
+
+        try {
+            await addGoogleDocUrlToSheet(
+                mockAuth,
+                testDocumentUrl,
+                testColumnUrl,
+                testTableRow
+            );
+            fail("addGoogleDocUrlToSheet should have thrown an exception");
+        } catch (e: unknown) {
+            if (e instanceof Error) {
+                expect(e.message).toBe("Unable to fetch sheet based on provided ID");
+            } else {
+                fail("exception should be instance of Error");
+            }
+        }
+    });
+
+    it("should throw an error if spreadsheetId is an empty string", async () => {
+        mockGet.mockImplementation(() => ({
+            data: {
+                spreadsheetId: "",
+            },
+        }));
+
+        try {
+            await addGoogleDocUrlToSheet(
+                mockAuth,
+                testDocumentUrl,
+                testColumnUrl,
+                testTableRow
+            );
+            fail("addGoogleDocUrlToSheet should have thrown an exception");
+        } catch (e: unknown) {
+            if (e instanceof Error) {
+                expect(e.message).toBe("Unable to fetch sheet based on provided ID");
+            } else {
+                fail("exception should be instance of Error");
+            }
+        }
+    });
+
+    it("should throw an error if spreadsheetId is undefined", async () => {
+        mockGet.mockImplementation(() => ({
+            data: {
+                spreadsheetId: undefined,
+            },
+        }));
+
+        try {
+            await addGoogleDocUrlToSheet(
+                mockAuth,
+                testDocumentUrl,
+                testColumnUrl,
+                testTableRow
+            );
+            fail("addGoogleDocUrlToSheet should have thrown an exception");
+        } catch (e: unknown) {
+            if (e instanceof Error) {
+                expect(e.message).toBe("Unable to fetch sheet based on provided ID");
+            } else {
+                fail("exception should be instance of Error");
+            }
+        }
+    });
+
+    it("should throw an error if spreadsheetId is null", async () => {
+        mockGet.mockImplementation(() => ({
+            data: {
+                spreadsheetId: null,
+            },
+        }));
+
+        try {
+            await addGoogleDocUrlToSheet(
+                mockAuth,
+                testDocumentUrl,
+                testColumnUrl,
+                testTableRow
+            );
+            fail("addGoogleDocUrlToSheet should have thrown an exception");
+        } catch (e: unknown) {
+            if (e instanceof Error) {
+                expect(e.message).toBe("Unable to fetch sheet based on provided ID");
+            } else {
+                fail("exception should be instance of Error");
+            }
+        }
+    });
+
+    it("should call to update the spreadsheet values", async () => {
+        await addGoogleDocUrlToSheet(
+            mockAuth,
+            testDocumentUrl,
+            testColumnUrl,
+            testTableRow
+        );
+
+        expect(mockUpdate).toBeCalledWith({
+            range: `${testColumnUrl}${testTableRow}`,
+            requestBody: {
+                range: `${testColumnUrl}${testTableRow}`,
+                values: [["test-document-url"]],
+            },
+            spreadsheetId: testSpreadsheetId,
+            valueInputOption: "USER_ENTERED",
+        });
+    });
+});

--- a/referral-form-data-process/lib/addGoogleDocUrlToSheet.test.ts
+++ b/referral-form-data-process/lib/addGoogleDocUrlToSheet.test.ts
@@ -8,163 +8,163 @@ const mockUpdate = jest.fn();
 jest.mock("googleapis");
 
 describe.only("#addGoogleDocUrlToSheet", () => {
-    const mockAuth = {
-        credentials: {
-            access_token: "actoken",
-            refresh_token: "rtoken",
-            scope: "https://www.googleapis.com/auth/drive.metadata.readonly",
-            token_type: "Bearer",
-            expiry_date: "1633950562052",
+  const mockAuth = {
+    credentials: {
+      access_token: "actoken",
+      refresh_token: "rtoken",
+      scope: "https://www.googleapis.com/auth/drive.metadata.readonly",
+      token_type: "Bearer",
+      expiry_date: "1633950562052",
+    },
+  } as unknown as OAuth2Client;
+
+  const testDocumentUrl = "test-document-url";
+  const testColumnUrl = "test-column-url";
+  const testTableRow = "test-table-row";
+  const testSpreadsheetId = "test-spreadsheet-id";
+  const googleSheetVersion = "v4";
+
+  beforeEach(() => {
+    (google.sheets as jest.Mock).mockImplementation(() => ({
+      spreadsheets: {
+        get: mockGet,
+        values: {
+          update: mockUpdate,
         },
-    } as unknown as OAuth2Client;
+      },
+    }));
 
-    const testDocumentUrl = "test-document-url";
-    const testColumnUrl = "test-column-url";
-    const testTableRow = "test-table-row";
-    const testSpreadsheetId = "test-spreadsheet-id";
-    const googleSheetVersion = "v4";
+    mockGet.mockImplementation(() => ({
+      data: {
+        spreadsheetId: testSpreadsheetId,
+      },
+    }));
+  });
 
-    beforeEach(() => {
-        (google.sheets as jest.Mock).mockImplementation(() => ({
-            spreadsheets: {
-                get: mockGet,
-                values: {
-                    update: mockUpdate,
-                },
-            },
-        }));
+  it("should call to sheets with our auth token", async () => {
+    await addGoogleDocUrlToSheet(
+      mockAuth,
+      testDocumentUrl,
+      testColumnUrl,
+      testTableRow
+    );
 
-        mockGet.mockImplementation(() => ({
-            data: {
-                spreadsheetId: testSpreadsheetId,
-            },
-        }));
+    expect(google.sheets).toBeCalledWith({
+      version: googleSheetVersion,
+      auth: mockAuth,
     });
+  });
 
-    it("should call to sheets with our auth token", async () => {
-        await addGoogleDocUrlToSheet(
-            mockAuth,
-            testDocumentUrl,
-            testColumnUrl,
-            testTableRow
-        );
+  it("should throw an error if sheet is undefined", async () => {
+    mockGet.mockImplementation(() => ({
+      data: undefined,
+    }));
 
-        expect(google.sheets).toBeCalledWith({
-            version: googleSheetVersion,
-            auth: mockAuth,
-        });
+    try {
+      await addGoogleDocUrlToSheet(
+        mockAuth,
+        testDocumentUrl,
+        testColumnUrl,
+        testTableRow
+      );
+      fail("addGoogleDocUrlToSheet should have thrown an exception");
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        expect(e.message).toBe("Unable to fetch sheet based on provided ID");
+      } else {
+        fail("exception should be instance of Error");
+      }
+    }
+  });
+
+  it("should throw an error if spreadsheetId is an empty string", async () => {
+    mockGet.mockImplementation(() => ({
+      data: {
+        spreadsheetId: "",
+      },
+    }));
+
+    try {
+      await addGoogleDocUrlToSheet(
+        mockAuth,
+        testDocumentUrl,
+        testColumnUrl,
+        testTableRow
+      );
+      fail("addGoogleDocUrlToSheet should have thrown an exception");
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        expect(e.message).toBe("Unable to fetch sheet based on provided ID");
+      } else {
+        fail("exception should be instance of Error");
+      }
+    }
+  });
+
+  it("should throw an error if spreadsheetId is undefined", async () => {
+    mockGet.mockImplementation(() => ({
+      data: {
+        spreadsheetId: undefined,
+      },
+    }));
+
+    try {
+      await addGoogleDocUrlToSheet(
+        mockAuth,
+        testDocumentUrl,
+        testColumnUrl,
+        testTableRow
+      );
+      fail("addGoogleDocUrlToSheet should have thrown an exception");
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        expect(e.message).toBe("Unable to fetch sheet based on provided ID");
+      } else {
+        fail("exception should be instance of Error");
+      }
+    }
+  });
+
+  it("should throw an error if spreadsheetId is null", async () => {
+    mockGet.mockImplementation(() => ({
+      data: {
+        spreadsheetId: null,
+      },
+    }));
+
+    try {
+      await addGoogleDocUrlToSheet(
+        mockAuth,
+        testDocumentUrl,
+        testColumnUrl,
+        testTableRow
+      );
+      fail("addGoogleDocUrlToSheet should have thrown an exception");
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        expect(e.message).toBe("Unable to fetch sheet based on provided ID");
+      } else {
+        fail("exception should be instance of Error");
+      }
+    }
+  });
+
+  it("should call to update the spreadsheet values", async () => {
+    await addGoogleDocUrlToSheet(
+      mockAuth,
+      testDocumentUrl,
+      testColumnUrl,
+      testTableRow
+    );
+
+    expect(mockUpdate).toBeCalledWith({
+      range: `${testColumnUrl}${testTableRow}`,
+      requestBody: {
+        range: `${testColumnUrl}${testTableRow}`,
+        values: [["test-document-url"]],
+      },
+      spreadsheetId: testSpreadsheetId,
+      valueInputOption: "USER_ENTERED",
     });
-
-    it("should throw an error if sheet is undefined", async () => {
-        mockGet.mockImplementation(() => ({
-            data: undefined,
-        }));
-
-        try {
-            await addGoogleDocUrlToSheet(
-                mockAuth,
-                testDocumentUrl,
-                testColumnUrl,
-                testTableRow
-            );
-            fail("addGoogleDocUrlToSheet should have thrown an exception");
-        } catch (e: unknown) {
-            if (e instanceof Error) {
-                expect(e.message).toBe("Unable to fetch sheet based on provided ID");
-            } else {
-                fail("exception should be instance of Error");
-            }
-        }
-    });
-
-    it("should throw an error if spreadsheetId is an empty string", async () => {
-        mockGet.mockImplementation(() => ({
-            data: {
-                spreadsheetId: "",
-            },
-        }));
-
-        try {
-            await addGoogleDocUrlToSheet(
-                mockAuth,
-                testDocumentUrl,
-                testColumnUrl,
-                testTableRow
-            );
-            fail("addGoogleDocUrlToSheet should have thrown an exception");
-        } catch (e: unknown) {
-            if (e instanceof Error) {
-                expect(e.message).toBe("Unable to fetch sheet based on provided ID");
-            } else {
-                fail("exception should be instance of Error");
-            }
-        }
-    });
-
-    it("should throw an error if spreadsheetId is undefined", async () => {
-        mockGet.mockImplementation(() => ({
-            data: {
-                spreadsheetId: undefined,
-            },
-        }));
-
-        try {
-            await addGoogleDocUrlToSheet(
-                mockAuth,
-                testDocumentUrl,
-                testColumnUrl,
-                testTableRow
-            );
-            fail("addGoogleDocUrlToSheet should have thrown an exception");
-        } catch (e: unknown) {
-            if (e instanceof Error) {
-                expect(e.message).toBe("Unable to fetch sheet based on provided ID");
-            } else {
-                fail("exception should be instance of Error");
-            }
-        }
-    });
-
-    it("should throw an error if spreadsheetId is null", async () => {
-        mockGet.mockImplementation(() => ({
-            data: {
-                spreadsheetId: null,
-            },
-        }));
-
-        try {
-            await addGoogleDocUrlToSheet(
-                mockAuth,
-                testDocumentUrl,
-                testColumnUrl,
-                testTableRow
-            );
-            fail("addGoogleDocUrlToSheet should have thrown an exception");
-        } catch (e: unknown) {
-            if (e instanceof Error) {
-                expect(e.message).toBe("Unable to fetch sheet based on provided ID");
-            } else {
-                fail("exception should be instance of Error");
-            }
-        }
-    });
-
-    it("should call to update the spreadsheet values", async () => {
-        await addGoogleDocUrlToSheet(
-            mockAuth,
-            testDocumentUrl,
-            testColumnUrl,
-            testTableRow
-        );
-
-        expect(mockUpdate).toBeCalledWith({
-            range: `${testColumnUrl}${testTableRow}`,
-            requestBody: {
-                range: `${testColumnUrl}${testTableRow}`,
-                values: [["test-document-url"]],
-            },
-            spreadsheetId: testSpreadsheetId,
-            valueInputOption: "USER_ENTERED",
-        });
-    });
+  });
 });

--- a/referral-form-data-process/lib/addGoogleDocUrlToSheet.ts
+++ b/referral-form-data-process/lib/addGoogleDocUrlToSheet.ts
@@ -2,33 +2,33 @@ import { OAuth2Client } from "google-auth-library";
 import { google } from "googleapis";
 
 export const addGoogleDocUrlToSheet = async (
-    auth: OAuth2Client,
-    documentURL: string,
-    urlColumn: string,
-    tableRow: string
+  auth: OAuth2Client,
+  documentURL: string,
+  urlColumn: string,
+  tableRow: string
 ) => {
-    const sheets = google.sheets({
-        version: "v4",
-        auth,
-    });
+  const sheets = google.sheets({
+    version: "v4",
+    auth,
+  });
 
-    const spreadsheetId = process.env.SPREADSHEET_ID as string;
+  const spreadsheetId = process.env.SPREADSHEET_ID as string;
 
-    const { data: sheet } = await sheets.spreadsheets.get({
-        spreadsheetId,
-    });
+  const { data: sheet } = await sheets.spreadsheets.get({
+    spreadsheetId,
+  });
 
-    if (!sheet || !sheet.spreadsheetId) {
-        throw new Error("Unable to fetch sheet based on provided ID");
-    }
+  if (!sheet || !sheet.spreadsheetId) {
+    throw new Error("Unable to fetch sheet based on provided ID");
+  }
 
-    await sheets.spreadsheets.values.update({
-        spreadsheetId: sheet.spreadsheetId,
-        range: `${urlColumn}${tableRow}`,
-        valueInputOption: "USER_ENTERED",
-        requestBody: {
-            range: `${urlColumn}${tableRow}`,
-            values: [[documentURL]],
-        },
-    });
+  await sheets.spreadsheets.values.update({
+    spreadsheetId: sheet.spreadsheetId,
+    range: `${urlColumn}${tableRow}`,
+    valueInputOption: "USER_ENTERED",
+    requestBody: {
+      range: `${urlColumn}${tableRow}`,
+      values: [[documentURL]],
+    },
+  });
 };

--- a/referral-form-data-process/lib/addGoogleDocUrlToSheet.ts
+++ b/referral-form-data-process/lib/addGoogleDocUrlToSheet.ts
@@ -1,0 +1,34 @@
+import { OAuth2Client } from "google-auth-library";
+import { google } from "googleapis";
+
+export const addGoogleDocUrlToSheet = async (
+    auth: OAuth2Client,
+    documentURL: string,
+    urlColumn: string,
+    tableRow: string
+) => {
+    const sheets = google.sheets({
+        version: "v4",
+        auth,
+    });
+
+    const spreadsheetId = process.env.SPREADSHEET_ID as string;
+
+    const { data: sheet } = await sheets.spreadsheets.get({
+        spreadsheetId,
+    });
+
+    if (!sheet || !sheet.spreadsheetId) {
+        throw new Error("Unable to fetch sheet based on provided ID");
+    }
+
+    await sheets.spreadsheets.values.update({
+        spreadsheetId: sheet.spreadsheetId,
+        range: `${urlColumn}${tableRow}`,
+        valueInputOption: "USER_ENTERED",
+        requestBody: {
+            range: `${urlColumn}${tableRow}`,
+            values: [[documentURL]],
+        },
+    });
+};

--- a/referral-form-data-process/main.test.ts
+++ b/referral-form-data-process/main.test.ts
@@ -1,6 +1,7 @@
 import { SQSEvent } from "aws-lambda/trigger/sqs";
 import { JWT } from "google-auth-library";
 import { createDocumentFromTemplate } from "./lib/createGoogleDocFromTemplate";
+import { addGoogleDocUrlToSheet } from "./lib/addGoogleDocUrlToSheet";
 import { generateAuth } from "./lib/generateGoogleAuth";
 import { getDataFromS3 } from "./lib/getDataFromS3";
 import { handler } from "./main";
@@ -8,6 +9,7 @@ import { handler } from "./main";
 jest.mock("./lib/getDataFromS3");
 jest.mock("./lib/generateGoogleAuth");
 jest.mock("./lib/createGoogleDocFromTemplate");
+jest.mock("./lib/addGoogleDocUrlToSheet");
 
 describe("#handler", () => {
   const sqsTriggerEvent = {
@@ -18,6 +20,7 @@ describe("#handler", () => {
     {
       data: ["This is a test"],
       id: ["100"],
+      FormRow: ["1"],
     },
   ];
 
@@ -25,10 +28,12 @@ describe("#handler", () => {
     {
       data: ["This is one"],
       id: ["1"],
+      FormRow: ["2"],
     },
     {
       name: ["This is another"],
       id: ["10"],
+      FormRow: ["3"],
     },
   ];
 
@@ -36,6 +41,8 @@ describe("#handler", () => {
   const testKey = "1234";
   const testTemplateId = "0001111";
   const testTitle = "A google document";
+  const urlColumn = "1";
+  const documentId = "12345";
 
   const googleAuthToken = { test: "this is a test token" } as unknown as JWT;
 
@@ -51,6 +58,10 @@ describe("#handler", () => {
     });
 
     (createDocumentFromTemplate as jest.Mock).mockImplementation(() => {
+      return { documentId: documentId };
+    });
+
+    (addGoogleDocUrlToSheet as jest.Mock).mockImplementation(() => {
       return {};
     });
 
@@ -58,6 +69,7 @@ describe("#handler", () => {
     process.env.PRIVATE_KEY = testKey;
     process.env.TEMPLATE_DOCUMENT_ID = testTemplateId;
     process.env.TITLE = testTitle;
+    process.env.URL_COLUMN = urlColumn;
   });
 
   it("it should call #getDataFromS3 when it receives an SQS event", async () => {
@@ -104,6 +116,18 @@ describe("#handler", () => {
       testTemplateId,
       testTitle,
       multipleS3ObjectArray[1]
+    );
+  });
+
+  it("should call to add the created document url to a google sheet", async () => {
+    const documentUrl = `https://docs.google.com/spreadsheets/d/${documentId}/edit`;
+    await handler(sqsTriggerEvent);
+
+    expect(addGoogleDocUrlToSheet).toBeCalledWith(
+      googleAuthToken,
+      documentUrl,
+      urlColumn,
+      singleS3ObjectArray[0].FormRow.toString()
     );
   });
 });

--- a/referral-form-data-process/main.test.ts
+++ b/referral-form-data-process/main.test.ts
@@ -120,7 +120,7 @@ describe("#handler", () => {
   });
 
   it("should call to add the created document url to a google sheet", async () => {
-    const documentUrl = `https://docs.google.com/spreadsheets/d/${documentId}/edit`;
+    const documentUrl = `https://docs.google.com/document/d/${documentId}/edit`;
     await handler(sqsTriggerEvent);
 
     expect(addGoogleDocUrlToSheet).toBeCalledWith(

--- a/referral-form-data-process/main.ts
+++ b/referral-form-data-process/main.ts
@@ -23,7 +23,7 @@ export const handler = async (sqsEvent: SQSEvent) => {
         title,
         formData
       );
-      const documentUrl = `https://docs.google.com/spreadsheets/d/${createdDocument.documentId}/edit`;
+      const documentUrl = `https://docs.google.com/document/d/${createdDocument.documentId}/edit`;
       await addGoogleDocUrlToSheet(
         googleAuthToken,
         documentUrl,

--- a/referral-form-data-process/main.ts
+++ b/referral-form-data-process/main.ts
@@ -1,4 +1,5 @@
 import { SQSEvent } from "aws-lambda";
+import { addGoogleDocUrlToSheet } from "./lib/addGoogleDocUrlToSheet";
 import { createDocumentFromTemplate } from "./lib/createGoogleDocFromTemplate";
 import { generateAuth } from "./lib/generateGoogleAuth";
 import { getDataFromS3 } from "./lib/getDataFromS3";
@@ -8,19 +9,27 @@ export const handler = async (sqsEvent: SQSEvent) => {
   const privateKey = process.env.PRIVATE_KEY as string;
   const templateDocumentId = process.env.TEMPLATE_DOCUMENT_ID as string;
   const title = process.env.TITLE as string;
+  const urlColumn = process.env.URL_COLUMN as string;
   const formattedPrivateKey = privateKey.replace(/\\n/g, "\n");
 
   const formDataObjects = await getDataFromS3(sqsEvent);
   const googleAuthToken = await generateAuth(clientEmail, formattedPrivateKey);
 
   await Promise.all(
-    formDataObjects.map((formData) =>
-      createDocumentFromTemplate(
+    formDataObjects.map(async (formData) => {
+      const createdDocument = await createDocumentFromTemplate(
         googleAuthToken,
         templateDocumentId,
         title,
         formData
-      )
-    )
+      );
+      const documentUrl = `https://docs.google.com/spreadsheets/d/${createdDocument.documentId}/edit`;
+      await addGoogleDocUrlToSheet(
+        googleAuthToken,
+        documentUrl,
+        urlColumn,
+        formData.FormRow.toString()
+      );
+    })
   );
 };

--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -25,6 +25,8 @@ functions:
       PRIVATE_KEY: ${opt:PRIVATE_KEY}
       TEMPLATE_DOCUMENT_ID: ${opt:TEMPLATE_DOCUMENT_ID}
       TITLE: ${opt:TITLE}
+      URL_COLUMN: ${opt:URL_COLUMN}
+      SPREADSHEET_ID: ${opt:SPREADSHEET_ID}
     handler: referral-form-data-process/main.handler
     events:
       - sqs:


### PR DESCRIPTION
### What
This PR adds a number of changes which allow a Google Doc link to be added to the spreadsheet for a form submission:

- Update the app script to send the form row of the newly added form submission to S3 along with the form data
- Add new function `addGoogleDocUrlToSheet` to be called on the lambda to update the spreadsheet with the link to a newly generated Google Doc for the respective form submission
- Add new environment variables: `URL_COLUMN` & `SPREADSHEET_ID` to the serverless and pipeline configuration.
- Update Readme

### Why
To allow members of the MASH team to access the information of a form submission on its respective Google Doc

### Anything else?
This is the second to last step for the lambda, the last piece of work is sending the form data to our database.