### PR TITLE
Fix(SCT-1464): Change the role used for assuming the Staging role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - aws_assume_role/assume_role:
           account: $AWS_ACCOUNT_STAGING
           profile_name: default
-          role: "circleci-assume-role"
+          role: "LBH_Circle_CI_Deployment_Role"
       - persist_to_workspace:
           root: *workspace_root
           paths:


### PR DESCRIPTION
The role we were using does not have permissions to deploy to Mosaic Production. This updates it to use the role that will allow it to deploy to the Staging APIs account.

Based off of what we currently do for the SCCV API [here](https://github.com/LBHackney-IT/social-care-case-viewer-api/blob/e3a907a4c8e02a74122bf87624151a472862c11c/.circleci/config.yml#L26).