### PR TITLE
Chore(SCT-1467): Add staging pipeline for lambda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,19 +160,22 @@ jobs:
     environment:
       TZ: "Europe/London"
 
-  compile-lambda:
+  deploy-lambda-to-staging:
     executor: node-executor
     working_directory: ~/project/referral-form-data-process
     steps:
       - *attach_workspace
       - run:
-          name: Compile Lambda
+          name: Compile lambda
           command: yarn tsc main.ts
+      - run:
+          name: "deploy lambda"
+          command: "yarn deploy -s staging --CLIENT_EMAIL $CLIENT_EMAIL --PRIVATE_KEY $PRIVATE_KEY --TEMPLATE_DOCUMENT_ID $TEMPLATE_DOCUMENT_ID --TITLE $TITLE --URL_COLUMN $URL_COLUMN --SPREADSHEET_ID $SPREADSHEET_ID"
       - persist_to_workspace:
           root: *workspace_root
           paths: .
 
-  deploy-lambda:
+  deploy-lambda-to-mosaic-production:
     executor: node-executor
     working_directory: ~/project/referral-form-data-process
     steps:
@@ -217,29 +220,30 @@ workflows:
       - unit-tests-lambda:
           requires:
             - install-dependencies-lambda
-      - permit-deploy-production:
-          type: approval
+      - deploy-lambda-to-staging:
           requires:
             - unit-tests-lambda
+            - terraform-init-then-apply-to-staging
+          filters:
+            branches:
+              only: main
+      - permit-lambda-deploy-mosaic-prod:
+          type: approval
+          requires:
+            - deploy-lambda-to-staging
           filters:
             branches:
               only: main
       - assume-role-mosaic-production:
           context: api-assume-role-social-care-production-context
           requires:
-            - permit-deploy-production
+            - permit-lambda-deploy-mosaic-prod
           filters:
             branches:
               only: main
-      - compile-lambda:
+      - deploy-lambda-to-mosaic-production:
           requires:
             - assume-role-mosaic-production
-          filters:
-            branches:
-              only: main
-      - deploy-lambda:
-          requires:
-            - compile-lambda
           filters:
             branches:
               only: main

--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -4,6 +4,7 @@ provider:
   name: aws
   runtime: nodejs14.x
   region: eu-west-2
+  stage: ${opt:stage}
   lambdaHashingVersion: 20201221
   iam:
     role:
@@ -11,15 +12,12 @@ provider:
         - Effect: "Allow"
           Action:
             - "s3:GetObject"
-          Resource:
-            Fn::Join:
-              - ""
-              - - "arn:aws:s3:::"
-                - "social-care-referrals-bucket"
-                - "/*"
+          Resource: "arn:aws:s3:::${self:custom.referralsBucket}/*"
 
 functions:
   main:
+    name: ${self:service}-${self:provider.stage}
+    handler: referral-form-data-process/main.handler
     environment:
       CLIENT_EMAIL: ${opt:CLIENT_EMAIL}
       PRIVATE_KEY: ${opt:PRIVATE_KEY}
@@ -27,7 +25,6 @@ functions:
       TITLE: ${opt:TITLE}
       URL_COLUMN: ${opt:URL_COLUMN}
       SPREADSHEET_ID: ${opt:SPREADSHEET_ID}
-    handler: referral-form-data-process/main.handler
     events:
       - sqs:
           arn:
@@ -36,4 +33,12 @@ functions:
               - - "arn:aws:sqs"
                 - Ref: "AWS::Region"
                 - Ref: "AWS::AccountId"
-                - "social-care-referrals-queue"
+                - "${self:custom.referralsQueue}"
+
+custom:
+  referralsBucket:
+    staging: social-care-referrals-stg-bucket
+    mosaic-prod: social-care-referrals-bucket
+  referralsQueue:
+    staging: social-care-referrals-stg-queue
+    mosaic-prod: social-care-referrals-queue


### PR DESCRIPTION
This adds changes to our circleCI pipeline and `serverless` config to include a Staging step for deploying the lambda.

- Updates the circleCI workflow to have steps for deploying the lambda to staging and mosaic prod
- Updates the `serverless` config so that the appropriate S3 bucket and SQS queues (depending on environment) are connected to lambda.

To Do After Merging:
- Update the environment variables to pull from AWS rather than as options in the pipeline. 