### PR TITLE
Chore(SCT-1467): Create secret manager resources for the Google credentials

### DIFF
--- a/terraform/mash-setup-staging/main.tf
+++ b/terraform/mash-setup-staging/main.tf
@@ -18,3 +18,23 @@ module "mash_data_processing" {
   region      = "eu-west-2"
   environment = "stg"
 }
+
+resource "aws_secretsmanager_secret" "gcp_service_account_client_email" {
+  name        = "${local.resource_prefix}-gcp-service-account-client-email"
+  description = "The client email associated with the Social Care Referrals Google Service Account"
+}
+
+resource "aws_secretsmanager_secret" "gcp_service_account_private_key" {
+  name        = "${local.resource_prefix}-gcp-service-account-private-key"
+  description = "The private key for the Social Care Referrals Google Service Account"
+}
+
+resource "aws_secretsmanager_secret" "referrals_google_doc_template_id" {
+  name        = "${local.resource_prefix}-referrals-google-doc-template-id"
+  description = "The ID of the MASH Google template document"
+}
+
+resource "aws_secretsmanager_secret" "referrals_google_spreadsheet_id" {
+  name        = "${local.resource_prefix}-referrals-google-spreadsheet-id"
+  description = "The ID of the MASH spreadsheet"
+}


### PR DESCRIPTION
We have sensitive values that the lambda needs to use to generate the google docs with the MASH form data.

This adds secret resources in AWS so that we can the lambda will have access to them.

After merging:
- Update the secrets in staging with the appropriate values
- Update `serverless` so the lambda can access the values.