### PR TITLE
Fix(SCT-1467): Move secret resources into module folder

### DIFF
--- a/terraform/mash-setup-staging/main.tf
+++ b/terraform/mash-setup-staging/main.tf
@@ -18,23 +18,3 @@ module "mash_data_processing" {
   region      = "eu-west-2"
   environment = "stg"
 }
-
-resource "aws_secretsmanager_secret" "gcp_service_account_client_email" {
-  name        = "${local.resource_prefix}-gcp-service-account-client-email"
-  description = "The client email associated with the Social Care Referrals Google Service Account"
-}
-
-resource "aws_secretsmanager_secret" "gcp_service_account_private_key" {
-  name        = "${local.resource_prefix}-gcp-service-account-private-key"
-  description = "The private key for the Social Care Referrals Google Service Account"
-}
-
-resource "aws_secretsmanager_secret" "referrals_google_doc_template_id" {
-  name        = "${local.resource_prefix}-referrals-google-doc-template-id"
-  description = "The ID of the MASH Google template document"
-}
-
-resource "aws_secretsmanager_secret" "referrals_google_spreadsheet_id" {
-  name        = "${local.resource_prefix}-referrals-google-spreadsheet-id"
-  description = "The ID of the MASH spreadsheet"
-}

--- a/terraform/modules/api-proxy-s3-sqs/secrets-for-mash-google-doc.tf
+++ b/terraform/modules/api-proxy-s3-sqs/secrets-for-mash-google-doc.tf
@@ -1,0 +1,19 @@
+resource "aws_secretsmanager_secret" "gcp_service_account_client_email" {
+  name        = "${local.resource_prefix}-gcp-service-account-client-email"
+  description = "The client email associated with the Social Care Referrals Google Service Account"
+}
+
+resource "aws_secretsmanager_secret" "gcp_service_account_private_key" {
+  name        = "${local.resource_prefix}-gcp-service-account-private-key"
+  description = "The private key for the Social Care Referrals Google Service Account"
+}
+
+resource "aws_secretsmanager_secret" "referrals_google_doc_template_id" {
+  name        = "${local.resource_prefix}-referrals-google-doc-template-id"
+  description = "The ID of the MASH Google template document"
+}
+
+resource "aws_secretsmanager_secret" "referrals_google_spreadsheet_id" {
+  name        = "${local.resource_prefix}-referrals-google-spreadsheet-id"
+  description = "The ID of the MASH spreadsheet"
+}


### PR DESCRIPTION
The resources couldn't access the local variable `resource_prefix` that was declared in the module folder.

This moves them into their own file within the module.