### PR TITLE
Fix(SCT-1467): Access the custom variable using the stage

### DIFF
--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -12,7 +12,7 @@ provider:
         - Effect: "Allow"
           Action:
             - "s3:GetObject"
-          Resource: "arn:aws:s3:::${self:custom.referralsBucket}/*"
+          Resource: "arn:aws:s3:::${self:custom.referralsBucket.${opt:stage}}/*"
 
 functions:
   main:
@@ -33,7 +33,7 @@ functions:
               - - "arn:aws:sqs"
                 - Ref: "AWS::Region"
                 - Ref: "AWS::AccountId"
-                - "${self:custom.referralsQueue}"
+                - "${self:custom.referralsQueue.${opt:stage}}"
 
 custom:
   referralsBucket:


### PR DESCRIPTION
We had an error in the pipeline [here](https://app.circleci.com/pipelines/github/LBHackney-IT/social-care-referral-form-ingestion/257/workflows/439168c8-0e47-4ab3-8fa2-90baa66cfe34/jobs/1095/parallel-runs/0/steps/0-103).

This happened because we were not accessing which value we wanted (which depends on the stage).

This amends the `serverless` config to access the appropriate names of the bucket and queue depending on the environment. 