### PR TITLE
Chore(SCT-1467): Allow lambda to access secret values for google doc generation

### DIFF
--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -19,10 +19,10 @@ functions:
     name: ${self:service}-${self:provider.stage}
     handler: referral-form-data-process/main.handler
     environment:
-      CLIENT_EMAIL: ${ssm:/aws/reference/secretsmanager/social-care-referrals-stg-gcp-service-account-client-email~true}
-      PRIVATE_KEY: ${ssm:/aws/reference/secretsmanager/social-care-referrals-stg-gcp-service-account-private-key~true}
-      TEMPLATE_DOCUMENT_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-stg-referrals-google-doc-template-id~true}
-      SPREADSHEET_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-stg-referrals-google-spreadsheet-id~true}
+      CLIENT_EMAIL: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-gcp-service-account-client-email~true}
+      PRIVATE_KEY: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-gcp-service-account-private-key~true}
+      TEMPLATE_DOCUMENT_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-referrals-google-doc-template-id~true}
+      SPREADSHEET_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-referrals-google-spreadsheet-id~true}
       ITLE: ${opt:TITLE}
       URL_COLUMN: ${opt:URL_COLUMN}
     events:
@@ -42,3 +42,6 @@ custom:
   referralsQueue:
     staging: social-care-referrals-stg-queue
     mosaic-prod: social-care-referrals-queue
+  environmentTag:
+    staging: stg
+    mosaic-prod: prod

--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -23,7 +23,7 @@ functions:
       PRIVATE_KEY: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-gcp-service-account-private-key~true}
       TEMPLATE_DOCUMENT_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-referrals-google-doc-template-id~true}
       SPREADSHEET_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-referrals-google-spreadsheet-id~true}
-      ITLE: ${opt:TITLE}
+      TITLE: ${opt:TITLE}
       URL_COLUMN: ${opt:URL_COLUMN}
     events:
       - sqs:

--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -19,12 +19,12 @@ functions:
     name: ${self:service}-${self:provider.stage}
     handler: referral-form-data-process/main.handler
     environment:
-      CLIENT_EMAIL: ${opt:CLIENT_EMAIL}
-      PRIVATE_KEY: ${opt:PRIVATE_KEY}
-      TEMPLATE_DOCUMENT_ID: ${opt:TEMPLATE_DOCUMENT_ID}
-      TITLE: ${opt:TITLE}
+      CLIENT_EMAIL: ${ssm:/aws/reference/secretsmanager/social-care-referrals-stg-gcp-service-account-client-email~true}
+      PRIVATE_KEY: ${ssm:/aws/reference/secretsmanager/social-care-referrals-stg-gcp-service-account-private-key~true}
+      TEMPLATE_DOCUMENT_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-stg-referrals-google-doc-template-id~true}
+      SPREADSHEET_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-stg-referrals-google-spreadsheet-id~true}
+      ITLE: ${opt:TITLE}
       URL_COLUMN: ${opt:URL_COLUMN}
-      SPREADSHEET_ID: ${opt:SPREADSHEET_ID}
     events:
       - sqs:
           arn:


### PR DESCRIPTION
Updates the serverless config so that the lambda retrieves the values of `CLIENT_EMAIL`, `PRIVATE_KEY`, `TEMPLATE_DOCUMENT_ID` and `SPREADSHEET_ID` from AWS secrets manager.

Note:
`TITLE` and `URL_COLUMN` are not saved as secrets in AWS.