### PR TITLE
Chore(SCT-1522): Add secrets for social care case viewer API access

### DIFF
--- a/terraform/modules/api-proxy-s3-sqs/secrets-for-mash-google-doc.tf
+++ b/terraform/modules/api-proxy-s3-sqs/secrets-for-mash-google-doc.tf
@@ -17,3 +17,13 @@ resource "aws_secretsmanager_secret" "referrals_google_spreadsheet_id" {
   name        = "${local.resource_prefix}-referrals-google-spreadsheet-id"
   description = "The ID of the MASH spreadsheet"
 }
+
+resource "aws_secretsmanager_secret" "case_viewer_service_api_endpoint" {
+  name        = "${local.resource_prefix}-service-api-endpoint"
+  description = "API endpoint for the Social Care Case Viewer System"
+}
+
+resource "aws_secretsmanager_secret" "case_viewer_service_api_aws_key" {
+  name        = "${local.resource_prefix}-service-api-aws-key"
+  description = "API key for the Social Care Case Viewer API"
+}


### PR DESCRIPTION
Adds terraform to create AWS resources for saving the values of the API endpoint and API key of the social care case viewer.

We POST the mash data to the SCCV API via the lambda. We need to save the endpoint and API key as environment variables the Lambda can access.