### PR TITLE
Fix(SCT-1522): Add `~true` to secrets manager parameter call

### DIFF
--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -25,8 +25,8 @@ functions:
       SPREADSHEET_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-referrals-google-spreadsheet-id~true}
       TITLE: ${opt:TITLE}
       URL_COLUMN: ${opt:URL_COLUMN}
-      ENDPOINT_API: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-service-api-endpoint}
-      AWS_KEY: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-service-api-aws-key}
+      ENDPOINT_API: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-service-api-endpoint~true}
+      AWS_KEY: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-service-api-aws-key~true}
     events:
       - sqs:
           arn:


### PR DESCRIPTION
During the deploy stage, `serverless` could not find the secrets for the API endpoint and API key.

From reading, when trying to access a secret in AWS, it seems we need to add `~true` to the end of the call in the `serverless` config.

We have `~true` set up already for the other environment variables and `serverless` has not warned about these ones.

This adds `~true` to try and fix `serverless` not getting the values for the API endpoint and key.