### PR TITLE
feat(SCT-1516): Add Github action to add and update the Repository tag

### DIFF
--- a/.github/workflows/github-action-tag-version.yml
+++ b/.github/workflows/github-action-tag-version.yml
@@ -1,0 +1,14 @@
+name: Update version tag
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Bump version and push tag
+        uses: hennejg/github-tag-action@v4.1.jh1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For us to import our MASH module into the infrastructure repo (so that we can deploy it to `Mosaic Production`), we need to pin its source repo (this repo) to a version. If we don't, the terraform linter raises an error, see [here](https://github.com/terraform-linters/tflint/blob/v0.33.1/docs/rules/terraform_module_pinned_source.md).

This introduces a Github action to add semantic versioning to our repo.
We could then reference the tag when importing our module, so that we pass this stage in linter.