### PR TITLE
feat(SCT-1463): Update readme with new section on testing the google services manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This project processes the data submitted via the MASH (Multi agency Safeguardin
       - [TODO: Terraform changes i.e MASH module](#todo-terraform-changes-ie-mash-module)
     - [Environment Variables](#environment-variables)
     - [How to configure CircleCI for automated deployment of our appscript](#how-to-configure-circleci-for-automated-deployment-of-our-appscript)
+  - [Testing](#testing)
+    - [Manually testing end-to-end](#manually-testing-end-to-end)
   - [Troubleshooting](#troubleshooting)
     - [Clasp push suddenly stops working](#clasp-push-suddenly-stops-working)
   - [Related repositories](#related-repositories)
@@ -165,6 +167,16 @@ Changes to the current production infrastructure can be made by editing the file
 3. In the script editor view go to settings (click cog icon)
 4. Copy the Script ID value
 5. Go to google-scripts/clasp.json and update the value associated with scriptId with what you just copied
+
+## Testing
+
+### Manually testing end-to-end
+
+Due to the interaction between Google services such as Google Forms, Docs and Sheets and our main application, it is important to test the full workflow for the MASH functionality manually. This involves filling out the Google Form and viewing the form response and generated Google Doc within the spreadsheet.
+
+A staging version of the Google Form, Document template, Sheet and Apps script (In-Progress) has been created to allow the ability to test the Google related services manually. The Google Form, Document Template and Sheet are held on the shared Google Drive for the Social Care project and has its own folder called _Referrals-MASH Workflow_. If you do not have access to this Drive you can contact one of the content managers of the Drive for access.
+
+(WIP: Add section related to Apps Script once the staging version has been created)
 
 ## Troubleshooting
 


### PR DESCRIPTION
### What
This small PR updates the readme with a new section on manually testing the Google side of the workflow (Docs, Sheets, Form)
### Why
To make it clear to others why we will have to manually test the full MASH workflow using the staging version of each Google service
### Anything else?
This section will likely be update to include a small bit on the staging Apps script once it has been create. I have purposely also left out any links to the Drive as I doubt we want to share that information publicly. Happy to add links if its better to include them.