### PR TITLE
Use v2 of checkout branch and latest version of imported Github action

### DIFF
--- a/.github/workflows/github-action-tag-version.yml
+++ b/.github/workflows/github-action-tag-version.yml
@@ -7,8 +7,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - name: Bump version and push tag
-        uses: hennejg/github-tag-action@v4.1.jh1
+      - uses: actions/checkout@v2
+      - name: Github Tag with semantic versioning
+        uses: hennejg/github-tag-action@v4.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses v2 of the checkout and uses the latest version of the Github action.