### PR TITLE
Chore(SCT-1516): Move setup for required providers into the module

### DIFF
--- a/terraform/mash-setup-staging/main.tf
+++ b/terraform/mash-setup-staging/main.tf
@@ -1,16 +1,6 @@
 provider "aws" {
   region = "eu-west-2"
 }
-
-terraform {
-  backend "s3" {}
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.0"
-    }
-  }
-}
 module "mash_data_processing" {
   source = "../modules/api-proxy-s3-sqs"
 

--- a/terraform/modules/api-proxy-s3-sqs/providers.tf
+++ b/terraform/modules/api-proxy-s3-sqs/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
While testing that we could import the MASH module into the [infrastructure repo](https://github.com/LBHackney-IT/infrastructure/runs/4432753234?check_suite_focus=true), terraform plan printed out this warning:
```
╷
│ Warning: Provider aws is undefined
│ 
│   on 50-mash-referrals-data-import.tf line 2, in module "mash_data_processing":
│    2:   providers = { aws = aws.core }
│ 
│ Module module.mash_data_processing does not declare a provider named aws.
│ If you wish to specify a provider configuration for the module, add an
│ entry for aws in the required_providers block within the module.
╵
```

This PR moves the required providers into the module, so that we can fix this warning.