### PR TITLE
Update lambda setup so that it points to the new MASH resources in production

### DIFF
--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -40,10 +40,10 @@ functions:
 custom:
   referralsBucket:
     staging: social-care-referrals-stg-bucket
-    mosaic-prod: social-care-referrals-bucket
+    mosaic-prod: social-care-referrals-prod-bucket
   referralsQueue:
     staging: social-care-referrals-stg-queue
-    mosaic-prod: social-care-referrals-queue
+    mosaic-prod: social-care-referrals-prod-queue
   environmentTag:
     staging: stg
     mosaic-prod: prod

--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -12,7 +12,7 @@ provider:
         - Effect: "Allow"
           Action:
             - "s3:GetObject"
-          Resource: "arn:aws:s3:::${self:custom.referralsBucket.${opt:stage}}/*"
+          Resource: "arn:aws:s3:::social-care-referrals-${self:custom.environmentTag.${opt:stage}}-bucket/*"
 
 functions:
   main:
@@ -35,15 +35,9 @@ functions:
               - - "arn:aws:sqs"
                 - Ref: "AWS::Region"
                 - Ref: "AWS::AccountId"
-                - "${self:custom.referralsQueue.${opt:stage}}"
+                - "social-care-referrals-${self:custom.environmentTag.${opt:stage}}-queue"
 
 custom:
-  referralsBucket:
-    staging: social-care-referrals-stg-bucket
-    mosaic-prod: social-care-referrals-prod-bucket
-  referralsQueue:
-    staging: social-care-referrals-stg-queue
-    mosaic-prod: social-care-referrals-prod-queue
   environmentTag:
     staging: stg
     mosaic-prod: prod


### PR DESCRIPTION
We've replaced our production terraform setup to use the MASH terraform module we created.

As a result, the old production S3 bucket and SQS no longer exist and new ones have replaced them.

The names of the new resources are slightly different.

This updates the `serverless` config so that the lambda can connect to these new resources and not the old (now deleted) resources.