### PR TITLE
feat(SCT-1571): Generate Google document title based on referral submitted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
           command: yarn tsc main.ts
       - run:
           name: "deploy lambda"
-          command: "yarn deploy -s staging --CLIENT_EMAIL $CLIENT_EMAIL --PRIVATE_KEY $PRIVATE_KEY --TEMPLATE_DOCUMENT_ID $TEMPLATE_DOCUMENT_ID --TITLE $TITLE --URL_COLUMN $URL_COLUMN --SPREADSHEET_ID $SPREADSHEET_ID"
+          command: "yarn deploy -s staging --CLIENT_EMAIL $CLIENT_EMAIL --PRIVATE_KEY $PRIVATE_KEY --TEMPLATE_DOCUMENT_ID $TEMPLATE_DOCUMENT_ID --URL_COLUMN $URL_COLUMN --SPREADSHEET_ID $SPREADSHEET_ID"
       - persist_to_workspace:
           root: *workspace_root
           paths: .
@@ -202,7 +202,7 @@ jobs:
       - *attach_workspace
       - run:
           name: "deploy"
-          command: "yarn deploy -s mosaic-prod --CLIENT_EMAIL $CLIENT_EMAIL --PRIVATE_KEY $PRIVATE_KEY --TEMPLATE_DOCUMENT_ID $TEMPLATE_DOCUMENT_ID --TITLE $TITLE --URL_COLUMN $URL_COLUMN --SPREADSHEET_ID $SPREADSHEET_ID --ENDPOINT_API $ENDPOINT_API --AWS_KEY $AWS_KEY"
+          command: "yarn deploy -s mosaic-prod --CLIENT_EMAIL $CLIENT_EMAIL --PRIVATE_KEY $PRIVATE_KEY --TEMPLATE_DOCUMENT_ID $TEMPLATE_DOCUMENT_ID --URL_COLUMN $URL_COLUMN --SPREADSHEET_ID $SPREADSHEET_ID --ENDPOINT_API $ENDPOINT_API --AWS_KEY $AWS_KEY"
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ To make any changes to the current social care referral production infrastructur
 ```text
   CLASP_REFRESH_TOKEN -- the refresh token to authenticate Clasp with Google
   URL_COLUMN -- column that contains the URLs to created google documents
-  TITLE -- the title of the google document
 ```
 
 ### How to configure CircleCI for automated deployment of our appscript

--- a/referral-form-data-process/lib/generateGoogleDocumentTitle.test.ts
+++ b/referral-form-data-process/lib/generateGoogleDocumentTitle.test.ts
@@ -1,0 +1,77 @@
+import { generateDocTitle } from "./generateGoogleDocumentTitle";
+
+describe("#generateDocTitle", () => {
+  it("should generate the title for the google document for one resident", () => {
+    const mockFormData = {
+      id: ["100"],
+      SubmissionRowPosition: ["1"],
+      "Child 1: Child's First Name": ["Sam"],
+      "Child 1: Child's Last Name": ["Smith"],
+      "Child 2: Child's First Name": [""],
+      "Child 2: Child's Last Name": [""],
+      "Child 3: Child's First Name": [""],
+      "Child 3: Child's Last Name": [""],
+    };
+
+    const actualValue = generateDocTitle(mockFormData);
+    const expectedValue = "Sam Smith | MASH";
+
+    expect(actualValue).toBe(expectedValue);
+  });
+
+  it("should display the number of other residents included within referral beside the first client's name", () => {
+    const mockFormData = {
+      id: ["100"],
+      SubmissionRowPosition: ["1"],
+      "Child 1: Child's First Name": ["Peter"],
+      "Child 1: Child's Last Name": ["Parker"],
+      "Child 2: Child's First Name": ["Mary"],
+      "Child 2: Child's Last Name": ["Jane"],
+      "Child 3: Child's First Name": ["Apple"],
+      "Child 3: Child's Last Name": ["Pie"],
+      "Child 4: Child's First Name": ["Banana"],
+      "Child 4: Child's Last Name": ["Pie"],
+      "Child 5: Child's First Name": [""],
+      "Child 5: Child's Last Name": [""],
+      "Child 6: Child's First Name": [""],
+      "Child 6: Child's Last Name": [""],
+      "Child 7: Child's First Name": [""],
+      "Child 7: Child's Last Name": [""],
+      "Child 8: Child's First Name": [""],
+      "Child 8: Child's Last Name": [""],
+    };
+
+    const actualValue = generateDocTitle(mockFormData);
+    const expectedValue = "Peter Parker +3 | MASH";
+
+    expect(actualValue).toBe(expectedValue);
+  });
+
+  it("should display 7 for the total number of other residents if all eight entries are filled in the form", () => {
+    const mockFormData = {
+      id: ["100"],
+      SubmissionRowPosition: ["1"],
+      "Child 1: Child's First Name": ["Apple"],
+      "Child 1: Child's Last Name": ["Pie"],
+      "Child 2: Child's First Name": ["Mary"],
+      "Child 2: Child's Last Name": ["Jane"],
+      "Child 3: Child's First Name": ["Cinnamon"],
+      "Child 3: Child's Last Name": ["Bread"],
+      "Child 4: Child's First Name": ["Banana"],
+      "Child 4: Child's Last Name": ["Pie"],
+      "Child 5: Child's First Name": ["Sam"],
+      "Child 5: Child's Last Name": ["Smith"],
+      "Child 6: Child's First Name": ["Alice"],
+      "Child 6: Child's Last Name": ["Wonderland"],
+      "Child 7: Child's First Name": ["Bob"],
+      "Child 7: Child's Last Name": ["Cat"],
+      "Child 8: Child's First Name": ["Joey"],
+      "Child 8: Child's Last Name": ["Right"],
+    };
+
+    const actualValue = generateDocTitle(mockFormData);
+    const expectedValue = "Apple Pie +7 | MASH";
+
+    expect(actualValue).toBe(expectedValue);
+  });
+});

--- a/referral-form-data-process/lib/generateGoogleDocumentTitle.test.ts
+++ b/referral-form-data-process/lib/generateGoogleDocumentTitle.test.ts
@@ -1,4 +1,4 @@
-import { generateDocTitle } from "./generateGoogleDocumentTitle";
+import { generateGoogleDocumentTitle } from "./generateGoogleDocumentTitle";
 
 describe("#generateDocTitle", () => {
   it("should generate the title for the google document for one resident", () => {
@@ -13,7 +13,7 @@ describe("#generateDocTitle", () => {
       "Child 3: Child's Last Name": [""],
     };
 
-    const actualValue = generateDocTitle(mockFormData);
+    const actualValue = generateGoogleDocumentTitle(mockFormData);
     const expectedValue = "Sam Smith | MASH";
 
     expect(actualValue).toBe(expectedValue);
@@ -41,7 +41,7 @@ describe("#generateDocTitle", () => {
       "Child 8: Child's Last Name": [""],
     };
 
-    const actualValue = generateDocTitle(mockFormData);
+    const actualValue = generateGoogleDocumentTitle(mockFormData);
     const expectedValue = "Peter Parker +3 | MASH";
 
     expect(actualValue).toBe(expectedValue);
@@ -69,7 +69,7 @@ describe("#generateDocTitle", () => {
       "Child 8: Child's Last Name": ["Right"],
     };
 
-    const actualValue = generateDocTitle(mockFormData);
+    const actualValue = generateGoogleDocumentTitle(mockFormData);
     const expectedValue = "Apple Pie +7 | MASH";
 
     expect(actualValue).toBe(expectedValue);

--- a/referral-form-data-process/lib/generateGoogleDocumentTitle.ts
+++ b/referral-form-data-process/lib/generateGoogleDocumentTitle.ts
@@ -1,7 +1,9 @@
 import { createListOfReferredClients } from "./helpers/createListOfReferredClients";
 import { mapFormDataToFormDataAnswersObject } from "./helpers/mapFormDataToFormDataAnswersObject";
 
-export const generateDocTitle = (formData: Record<string, string[]>) => {
+export const generateGoogleDocumentTitle = (
+  formData: Record<string, string[]>
+) => {
   const service = "MASH";
   const mappedDataObject = mapFormDataToFormDataAnswersObject(formData);
   const clientList = createListOfReferredClients(mappedDataObject);

--- a/referral-form-data-process/lib/generateGoogleDocumentTitle.ts
+++ b/referral-form-data-process/lib/generateGoogleDocumentTitle.ts
@@ -1,0 +1,18 @@
+import { createListOfReferredClients } from "./helpers/createListOfReferredClients";
+import { mapFormDataToFormDataAnswersObject } from "./helpers/mapFormDataToFormDataAnswersObject";
+
+export const generateDocTitle = (formData: Record<string, string[]>) => {
+  const service = "MASH";
+  const mappedDataObject = mapFormDataToFormDataAnswersObject(formData);
+  const clientList = createListOfReferredClients(mappedDataObject);
+
+  const clientOneFullName = clientList[0];
+
+  const numberOfOtherClientsInReferral = clientList.length - 1;
+
+  if (numberOfOtherClientsInReferral > 0) {
+    return `${clientOneFullName} +${numberOfOtherClientsInReferral} | ${service}`;
+  }
+
+  return `${clientOneFullName} | ${service}`;
+};

--- a/referral-form-data-process/lib/helpers/createListOfReferredClients.ts
+++ b/referral-form-data-process/lib/helpers/createListOfReferredClients.ts
@@ -1,0 +1,78 @@
+export const createListOfReferredClients = (
+  formDataAnswersObject: FormDataAnswersObject
+) => {
+  let clientsValue: string[] | undefined = [];
+
+  const clientOne = getClientFullName(
+    formDataAnswersObject.clientOneFirstName,
+    formDataAnswersObject.clientOneLastName
+  );
+
+  const clientTwo = getClientFullName(
+    formDataAnswersObject.clientTwoFirstName,
+    formDataAnswersObject.clientTwoLastName
+  );
+
+  const clientThree = getClientFullName(
+    formDataAnswersObject.clientThreeFirstName,
+    formDataAnswersObject.clientThreeLastName
+  );
+
+  const clientFour = getClientFullName(
+    formDataAnswersObject.clientFourFirstName,
+    formDataAnswersObject.clientFourLastName
+  );
+
+  const clientFive = getClientFullName(
+    formDataAnswersObject.clientFiveFirstName,
+    formDataAnswersObject.clientFiveLastName
+  );
+
+  const clientSix = getClientFullName(
+    formDataAnswersObject.clientSixFirstName,
+    formDataAnswersObject.clientSixLastName
+  );
+
+  const clientSeven = getClientFullName(
+    formDataAnswersObject.clientSevenFirstName,
+    formDataAnswersObject.clientSevenLastName
+  );
+
+  const clientEight = getClientFullName(
+    formDataAnswersObject.clientEightFirstName,
+    formDataAnswersObject.clientEightLastName
+  );
+
+  if (clientOne) {
+    clientsValue.push(clientOne);
+  }
+  if (clientTwo) {
+    clientsValue.push(clientTwo);
+  }
+  if (clientThree) {
+    clientsValue.push(clientThree);
+  }
+  if (clientFour) {
+    clientsValue.push(clientFour);
+  }
+  if (clientFive) {
+    clientsValue.push(clientFive);
+  }
+  if (clientSix) {
+    clientsValue.push(clientSix);
+  }
+  if (clientSeven) {
+    clientsValue.push(clientSeven);
+  }
+  if (clientEight) {
+    clientsValue.push(clientEight);
+  }
+
+  function getClientFullName(firstName?: string, lastName?: string) {
+    if (firstName && lastName) {
+      return `${firstName} ${lastName}`;
+    } else return null;
+  }
+
+  return clientsValue;
+};

--- a/referral-form-data-process/lib/helpers/mapFormDataToFormDataAnswersObject.ts
+++ b/referral-form-data-process/lib/helpers/mapFormDataToFormDataAnswersObject.ts
@@ -1,0 +1,62 @@
+export const mapFormDataToFormDataAnswersObject = (
+  formData: Record<string, string[]>
+) => {
+  const formDataAnswersObject: FormDataAnswersObject = {
+    referrerFirstName: undefined,
+    referrerLastName: undefined,
+    clientOneFirstName: undefined,
+    clientOneLastName: undefined,
+    clientTwoFirstName: undefined,
+    clientTwoLastName: undefined,
+    clientThreeFirstName: undefined,
+    clientThreeLastName: undefined,
+    clientFourFirstName: undefined,
+    clientFourLastName: undefined,
+    clientFiveFirstName: undefined,
+    clientFiveLastName: undefined,
+    clientSixFirstName: undefined,
+    clientSixLastName: undefined,
+    clientSevenFirstName: undefined,
+    clientSevenLastName: undefined,
+    clientEightFirstName: undefined,
+    clientEightLastName: undefined,
+    requestedSupport: undefined,
+  };
+
+  const formQuestionToPropertyMap = new Map([
+    ["Referrer First Name", "referrerFirstName"],
+    ["Referrer Last Name", "referrerLastName"],
+    ["Child 1: Child's First Name", "clientOneFirstName"],
+    ["Child 1: Child's Last Name", "clientOneLastName"],
+    ["Child 2: Child's First Name", "clientTwoFirstName"],
+    ["Child 2: Child's Last Name", "clientTwoLastName"],
+    ["Child 3: Child's First Name", "clientThreeFirstName"],
+    ["Child 3: Child's Last Name", "clientThreeLastName"],
+    ["Child 4: Child's First Name", "clientFourFirstName"],
+    ["Child 4: Child's Last Name", "clientFourLastName"],
+    ["Child 5: Child's First Name", "clientFiveFirstName"],
+    ["Child 5: Child's Last Name", "clientFiveLastName"],
+    ["Child 6: Child's First Name", "clientSixFirstName"],
+    ["Child 6: Child's Last Name", "clientSixLastName"],
+    ["Child 7: Child's First Name", "clientSevenFirstName"],
+    ["Child 7: Child's Last Name", "clientSevenLastName"],
+    ["Child 8: Child's First Name", "clientEightFirstName"],
+    ["Child 8: Child's Last Name", "clientEightLastName"],
+    [
+      "What support do you think the child(ren) would benefit from?",
+      "requestedSupport",
+    ],
+  ]);
+
+  const dataEntries = Object.entries(formData);
+
+  for (const [key, value] of dataEntries) {
+    if (formQuestionToPropertyMap.has(key)) {
+      formDataAnswersObject[
+        formQuestionToPropertyMap.get(key) as keyof FormDataAnswersObject
+      ] = value.toString();
+    }
+  }
+
+  return formDataAnswersObject;
+};

--- a/referral-form-data-process/lib/interfaces/formDataAnswers.ts
+++ b/referral-form-data-process/lib/interfaces/formDataAnswers.ts
@@ -1,0 +1,21 @@
+interface FormDataAnswersObject {
+  referrerFirstName: string | undefined;
+  referrerLastName: string | undefined;
+  clientOneFirstName: string | undefined;
+  clientOneLastName: string | undefined;
+  clientTwoFirstName: string | undefined;
+  clientTwoLastName: string | undefined;
+  clientThreeFirstName: string | undefined;
+  clientThreeLastName: string | undefined;
+  clientFourFirstName: string | undefined;
+  clientFourLastName: string | undefined;
+  clientFiveFirstName: string | undefined;
+  clientFiveLastName: string | undefined;
+  clientSixFirstName: string | undefined;
+  clientSixLastName: string | undefined;
+  clientSevenFirstName: string | undefined;
+  clientSevenLastName: string | undefined;
+  clientEightFirstName: string | undefined;
+  clientEightLastName: string | undefined;
+  requestedSupport: string | undefined;
+}

--- a/referral-form-data-process/main.ts
+++ b/referral-form-data-process/main.ts
@@ -2,6 +2,7 @@ import { SQSEvent } from "aws-lambda";
 import { addGoogleDocUrlToSheet } from "./lib/addGoogleDocUrlToSheet";
 import { createDocumentFromTemplate } from "./lib/createGoogleDocFromTemplate";
 import { generateAuth } from "./lib/generateGoogleAuth";
+import { generateGoogleDocumentTitle } from "./lib/generateGoogleDocumentTitle";
 import { getDataFromS3 } from "./lib/getDataFromS3";
 import { sendDataToAPI } from "./lib/sendDataToAPI";
 
@@ -9,7 +10,6 @@ export const handler = async (sqsEvent: SQSEvent) => {
   const clientEmail = process.env.CLIENT_EMAIL as string;
   const privateKey = process.env.PRIVATE_KEY as string;
   const templateDocumentId = process.env.TEMPLATE_DOCUMENT_ID as string;
-  const title = process.env.TITLE as string;
   const urlColumn = process.env.URL_COLUMN as string;
   const formattedPrivateKey = privateKey.replace(/\\n/g, "\n");
 
@@ -18,10 +18,11 @@ export const handler = async (sqsEvent: SQSEvent) => {
 
   await Promise.all(
     formDataObjects.map(async (formData) => {
+      const documentTitle = generateGoogleDocumentTitle(formData);
       const createdDocument = await createDocumentFromTemplate(
         googleAuthToken,
         templateDocumentId,
-        title,
+        documentTitle,
         formData
       );
       const documentUrl = `https://docs.google.com/document/d/${createdDocument.documentId}/edit`;

--- a/referral-form-data-process/serverless.yml
+++ b/referral-form-data-process/serverless.yml
@@ -23,7 +23,6 @@ functions:
       PRIVATE_KEY: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-gcp-service-account-private-key~true}
       TEMPLATE_DOCUMENT_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-referrals-google-doc-template-id~true}
       SPREADSHEET_ID: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-referrals-google-spreadsheet-id~true}
-      TITLE: ${opt:TITLE}
       URL_COLUMN: ${opt:URL_COLUMN}
       ENDPOINT_API: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-service-api-endpoint~true}
       AWS_KEY: ${ssm:/aws/reference/secretsmanager/social-care-referrals-${self:custom.environmentTag.${opt:stage}}-service-api-aws-key~true}


### PR DESCRIPTION
The referral process generates a Google Document that a member of MASH would use.

We want to have each document generated to have a unique name that will help distinguish them. Currently, there is no title set so the name of the documents default to the word true

Title should follow the format:

`resident's name | service` e.g Sam Smith | MASH or if there are multiple residents, add the number of additional referrals to the first client's name e.g Sam Smith +3 | MASH

This adds a function that will grab the first client's full name from a referral, count any other residents in the referral and use the information to create a title that matches the format above.
