### PR TITLE
fix(SCT-1571): Export interface to fix typescript compile error

### DIFF
--- a/referral-form-data-process/lib/helpers/createListOfReferredClients.ts
+++ b/referral-form-data-process/lib/helpers/createListOfReferredClients.ts
@@ -1,3 +1,5 @@
+import { FormDataAnswersObject } from "../interfaces/formDataAnswers";
+
 export const createListOfReferredClients = (
   formDataAnswersObject: FormDataAnswersObject
 ) => {

--- a/referral-form-data-process/lib/helpers/mapFormDataToFormDataAnswersObject.ts
+++ b/referral-form-data-process/lib/helpers/mapFormDataToFormDataAnswersObject.ts
@@ -1,3 +1,5 @@
+import { FormDataAnswersObject } from "../interfaces/formDataAnswers";
+
 export const mapFormDataToFormDataAnswersObject = (
   formData: Record<string, string[]>
 ) => {

--- a/referral-form-data-process/lib/interfaces/formDataAnswers.ts
+++ b/referral-form-data-process/lib/interfaces/formDataAnswers.ts
@@ -1,4 +1,4 @@
-interface FormDataAnswersObject {
+export interface FormDataAnswersObject {
   referrerFirstName: string | undefined;
   referrerLastName: string | undefined;
   clientOneFirstName: string | undefined;


### PR DESCRIPTION
In the build pipeline, when we compile the lambda we get an error: `error TS2304: Cannot find name 'FormDataAnswersObject'.`

This commit exports the interface so that the interface can be found during compiling.